### PR TITLE
fix typo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,8 +11,8 @@ With Testinfra you can write unit tests in Python to test *actual state* of
 your servers configured by managements tools like Salt_, Ansible_, Puppet_,
 Chef_ and so on.
 
-Testinfra aims to be a ServerSpec_ equivalent in python and is written as
-a plugin to the powerfull Pytest_ test engine
+Testinfra aims to be a Serverspec_ equivalent in python and is written as
+a plugin to the powerful Pytest_ test engine
 
 .. warning:: Testinfra is currently *alpha* software, API may change before the
              first release, and OS support is limited.
@@ -72,5 +72,5 @@ And run it::
 .. _Ansible: http://www.ansible.com/
 .. _Puppet: https://puppetlabs.com/
 .. _Chef: https://www.chef.io/
-.. _ServerSpec: http://serverspec.org/
+.. _Serverspec: http://serverspec.org/
 .. _Pytest: http://pytest.org

--- a/doc/source/examples.rst
+++ b/doc/source/examples.rst
@@ -4,7 +4,7 @@ Examples
 Parametrize test
 ~~~~~~~~~~~~~~~~
 
-This examples introduces some usefull `pytest <http://pytest.org>`_ features.
+This examples introduces some useful `pytest <http://pytest.org>`_ features.
 Especially about proper and efficient looping in tests assertions.
 
 The purpose of the test is to verify the security of php config by

--- a/testinfra/modules/command.py
+++ b/testinfra/modules/command.py
@@ -32,7 +32,7 @@ class Command(Module):
     ''
 
 
-    Good practice: always use shell arguments quotting to avoid shell injection
+    Good practice: always use shell arguments quoting to avoid shell injection
 
 
     >>> cmd = Command("ls -l -- %s", "/;echo inject")

--- a/testinfra/modules/systeminfo.py
+++ b/testinfra/modules/systeminfo.py
@@ -101,7 +101,7 @@ class SystemInfo(Module):
 
     @property
     def codename(self):
-        """Relase code name
+        """Release code name
 
         >>> SystemInfo.codename
         'wheezy'


### PR DESCRIPTION
found by aspell.

`Serverspec` is originated from `Server` + `RSpec`, not `Server` + `Spec`.
So 2nd `s` is not need to be capitalized.