### PR TITLE
Docker Backend added

### DIFF
--- a/testinfra/backend/__init__.py
+++ b/testinfra/backend/__init__.py
@@ -19,6 +19,7 @@ from testinfra.backend import local
 from testinfra.backend import paramiko
 from testinfra.backend import salt
 from testinfra.backend import ssh
+from testinfra.backend import docker
 
 BACKENDS = dict((klass.get_backend_type(), klass) for klass in (
     local.LocalBackend,
@@ -26,6 +27,7 @@ BACKENDS = dict((klass.get_backend_type(), klass) for klass in (
     ssh.SafeSshBackend,
     paramiko.ParamikoBakend,
     salt.SaltBackend,
+    docker.DockerBackend,
 ))
 
 

--- a/testinfra/backend/docker.py
+++ b/testinfra/backend/docker.py
@@ -1,0 +1,59 @@
+# -*- coding: utf8 -*-
+# Copyright © 2015 Philippe Pepiot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import unicode_literals
+from __future__ import absolute_import
+
+from testinfra.backend import base
+
+import os
+
+try:
+    from docker import Client
+except ImportError:
+    HAS_DOCKER = False
+else:
+    HAS_DOCKER = True
+
+
+class DockerBackend(base.BaseBackend):
+    _backend_type = "docker"
+
+    def __init__(self, host, *args, **kwargs):
+        if not HAS_DOCKER:
+            raise RuntimeError((
+                "You must install docker-py package (pip install docker-py) "
+                "to use the docker-py backend"))
+        self.docker_host = os.getenv("DOCKER_HOST", "/var/run/docker.sock")
+        self.image = host
+        self.cli = Client(base_url=self.docker_host)
+
+        super(DockerBackend, self).__init__(*args, **kwargs)
+
+    def run(self, command, *args, **kwargs):
+        container = self.cli.create_container(self.image,
+                                              "tail -f /dev/null")
+        self.cli.start(container)
+        inspect = self.cli.inspect_container(container)
+        if not inspect['State']['Running']:
+            raise RuntimeError("Docker Container Start Failed")
+
+        execution = self.cli.exec_create(container,
+                                         self.quote(command, *args),)
+        out = self.cli.exec_start(execution)
+        inspection = self.cli.exec_inspect(execution)
+        self.cli.remove_container(container, v=True, force=True, )
+        return base.CommandResult(self,
+                                  inspection["ExitCode"], out, "", command)

--- a/testinfra/plugin.py
+++ b/testinfra/plugin.py
@@ -80,7 +80,7 @@ def pytest_addoption(parser):
         "--connection",
         action="store",
         dest="connection",
-        help="Remote connection backend paramiko|ssh|safe_ssh|salt",
+        help="Remote connection backend paramiko|ssh|safe_ssh|salt|docker",
     )
     group._addoption(
         "--hosts",


### PR DESCRIPTION
Good day, first of all, thanks for your work.
Here as backend for docker. For this backend the list of hosts are treated as docker images.
Usage:

```
testinfra --connection=docker --hosts=centos,alpine:3.1 test.py
```

I've been thinking about putting docker_host parameter in backend __init__ to command line parameters, but its occur that all the parameters are defined in plugin.py. You possibly should think about providing backend specific parameters in backend code, not in one central file.
