### PR TITLE
check if minion is up first before run_salt()

### DIFF
--- a/testinfra/backend/salt.py
+++ b/testinfra/backend/salt.py
@@ -53,4 +53,7 @@ class SaltBackend(base.BaseBackend):
             self, out['retcode'], out['stdout'], out['stderr'], command)
 
     def run_salt(self, func, args=None):
-        return self.client.cmd(self.host, func, args or [])[self.host]
+        if self.client.cmd(self.host, "test.ping"):
+            return self.client.cmd(self.host, func, args or [])[self.host]
+        else:
+            raise RuntimeError("Minion did not return. [No response]")


### PR DESCRIPTION
Hello,

I have added a check before passing returning any commands from `run_salt()` using `test.ping` so if minion is down it will raise an error, i have tested it already but i will test it again soon to be sure enough.

Thanks