### PR TITLE
get a list of all connected minions if asterisk passed to --hosts

### DIFF
--- a/testinfra/plugin.py
+++ b/testinfra/plugin.py
@@ -105,8 +105,8 @@ def pytest_addoption(parser):
 
 def pytest_generate_tests(metafunc):
     if "_testinfra_host" in metafunc.fixturenames:
-        if (metafunc.config.option.hosts == "*" and 
-           metafunc.config.option.connection == "salt"):
+        if (metafunc.config.option.hosts == "*" and
+            metafunc.config.option.connection == "salt"):
             import salt.runner
             opts = salt.config.master_config("/etc/salt/master")
             runner = salt.runner.RunnerClient(opts)

--- a/testinfra/plugin.py
+++ b/testinfra/plugin.py
@@ -105,6 +105,12 @@ def pytest_addoption(parser):
 
 def pytest_generate_tests(metafunc):
     if "_testinfra_host" in metafunc.fixturenames:
+        if metafunc.config.option.hosts == "*" and metafunc.config.option.connection == "salt":
+           import salt.runner
+           opts = salt.config.master_config("/etc/salt/master")
+           runner = salt.runner.RunnerClient(opts)
+           minions_list = runner.cmd("manage.up",[])
+           metafunc.config.option.hosts = ",".join(minions_list)
         if metafunc.config.option.hosts is not None:
             params = metafunc.config.option.hosts.split(",")
             ids = params

--- a/testinfra/plugin.py
+++ b/testinfra/plugin.py
@@ -105,12 +105,13 @@ def pytest_addoption(parser):
 
 def pytest_generate_tests(metafunc):
     if "_testinfra_host" in metafunc.fixturenames:
-        if metafunc.config.option.hosts == "*" and metafunc.config.option.connection == "salt":
-           import salt.runner
-           opts = salt.config.master_config("/etc/salt/master")
-           runner = salt.runner.RunnerClient(opts)
-           minions_list = runner.cmd("manage.up",[])
-           metafunc.config.option.hosts = ",".join(minions_list)
+        if (metafunc.config.option.hosts == "*" and 
+           metafunc.config.option.connection == "salt"):
+            import salt.runner
+            opts = salt.config.master_config("/etc/salt/master")
+            runner = salt.runner.RunnerClient(opts)
+            minions_list = runner.cmd("manage.up", [])
+            metafunc.config.option.hosts = ",".join(minions_list)
         if metafunc.config.option.hosts is not None:
             params = metafunc.config.option.hosts.split(",")
             ids = params

--- a/testinfra/plugin.py
+++ b/testinfra/plugin.py
@@ -106,7 +106,7 @@ def pytest_addoption(parser):
 def pytest_generate_tests(metafunc):
     if "_testinfra_host" in metafunc.fixturenames:
         if (metafunc.config.option.hosts == "*" and
-            metafunc.config.option.connection == "salt"):
+                metafunc.config.option.connection == "salt"):
             import salt.runner
             opts = salt.config.master_config("/etc/salt/master")
             runner = salt.runner.RunnerClient(opts)


### PR DESCRIPTION
Hello,

As a SaltStack user , sometimes i need to use an asterisk to execute something on all minions, and thats also would be the case if i am testing a new state and would like to see how it works on all my minions, instead of typing the name of each minion (in my case i may test on 5 minions or more [different distors for example] ) it would be easier to pass an asterisk instead of typing the name of each minion. so i made the following modification:

```python
if (metafunc.config.option.hosts == "*" and
        metafunc.config.option.connection == "salt"):
           import salt.runner
           opts = salt.config.master_config("/etc/salt/master")
           runner = salt.runner.RunnerClient(opts)
           minions_list = runner.cmd("manage.up", [])
           metafunc.config.option.hosts = ",".join(minions_list)
```

it may be slow a little but its handy!