### PR TITLE
Properly check package.is_installed tests for rpm based system

### DIFF
--- a/testinfra/modules/package.py
+++ b/testinfra/modules/package.py
@@ -101,7 +101,7 @@ class RpmPackage(Package):
 
     @property
     def is_installed(self):
-        return self.run_test("rpm -q %s", self.name)
+        return self.run_test("rpm -q %s", self.name).rc == 0
 
     @property
     def version(self):


### PR DESCRIPTION
Noticed that package.is_installed didn't seem to properly verify that the package was actually installed. So here's a quick fix.