### PR TITLE
Make File.mode be in octal form

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ Write your first tests file to `test_myinfra.py`::
         assert passwd.contains("root")
         assert passwd.user == "root"
         assert passwd.group == "root"
-        assert passwd.mode == 644
+        assert passwd.mode == 0o644
 
 
     def test_nginx_is_installed(Package):

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -12,8 +12,8 @@ connection and call fonction from modules::
     >>> import testinfra
     >>> conn = testinfra.get_backend("paramiko://root@server:2222", sudo=True)
     >>> File = conn.get_module("File")
-    >>> File("/etc/shadow").mode
-    640
+    >>> File("/etc/shadow").mode == 0o640
+    True
 
 Same applies to all :ref:`modules`.
 

--- a/testinfra/test/test_file.py
+++ b/testinfra/test/test_file.py
@@ -34,7 +34,7 @@ def test_file(remote_tempdir, Command, SystemInfo, File):
     assert f.uid == uid
     assert f.gid == gid
     assert f.group == group
-    assert f.mode == 600
+    assert f.mode == 0o600
     assert f.contains("fo")
     assert not f.is_directory
     assert not f.is_symlink


### PR DESCRIPTION
**This is a backwards incompatible change**

Currently with `testinfra`, `File.mode` is provided as a decimal integer `644`, but it should be represented as an octal integer `0o644`, since this is how it is given to us by the os.

This change aligns with the Python standard library which uses an octal integer for `os.stat`.

```python
import os
import stat

s = os.stat('/etc/passwd')
mode = stat.S_IMODE(s.st_mode)
mode == 420
oct(420) == '0644'  # '0o644' in python 3
```

This also means we can utilize the file mode octal constants in the `stat` module for tests.

```python
import stat

def test_user_readable(File):
    passwd = File('/etc/passwd')
    assert passwd.mode & stat.S_IRUSR

def test_not_other_executable(File):
    passwd = File('/etc/passwd')
    assert not passwd.mode & stat.S_IXOTH

def test_file_mode(File):
    passwd = File('/etc/passwd')
    assert passwd.mode == (stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH)
```