### PR TITLE
Added slash at the end of rc?.d path

### DIFF
--- a/testinfra/modules/service.py
+++ b/testinfra/modules/service.py
@@ -81,7 +81,7 @@ class SysvService(Service):
     @property
     def is_enabled(self):
         return bool(self.check_output(
-            "find /etc/rc?.d -name %s",
+            "find /etc/rc?.d/ -name %s",
             "S??" + self.name,
         ))
 


### PR DESCRIPTION
In case of symlink path, find will start from symlink target.

```
[root@ae2c458b4cac /]# ls -l /etc/rc?.d
lrwxrwxrwx 1 root root 10 Jun 15 19:21 /etc/rc0.d -> rc.d/rc0.d
lrwxrwxrwx 1 root root 10 Jun 15 19:21 /etc/rc1.d -> rc.d/rc1.d
lrwxrwxrwx 1 root root 10 Jun 15 19:21 /etc/rc2.d -> rc.d/rc2.d
lrwxrwxrwx 1 root root 10 Jun 15 19:21 /etc/rc3.d -> rc.d/rc3.d
lrwxrwxrwx 1 root root 10 Jun 15 19:21 /etc/rc4.d -> rc.d/rc4.d
lrwxrwxrwx 1 root root 10 Jun 15 19:21 /etc/rc5.d -> rc.d/rc5.d
lrwxrwxrwx 1 root root 10 Jun 15 19:21 /etc/rc6.d -> rc.d/rc6.d
```
```
[root@ae2c458b4cac /]# find /etc/rc?.d -name 'S??sssd'
[root@ae2c458b4cac /]# find /etc/rc?.d/ -name 'S??sssd'
/etc/rc2.d/S12sssd
/etc/rc3.d/S12sssd
/etc/rc4.d/S12sssd
/etc/rc5.d/S12sssd
[root@ae2c458b4cac /]#
```