### PR TITLE
Return puppet facts when calling Facter

### DIFF
--- a/testinfra/modules/puppet.py
+++ b/testinfra/modules/puppet.py
@@ -106,7 +106,7 @@ class Facter(InstanceModule):
     """
 
     def __call__(self, *facts):
-        cmd = "facter --json " + " ".join(facts)
+        cmd = "facter --json --puppet " + " ".join(facts)
         return json.loads(self.check_output(cmd))
 
     def __repr__(self):


### PR DESCRIPTION
When calling facter, make sure the puppet facts are included in the output.