### PR TITLE
Fix quoting bug which prevented running quote-requiring commands with sudo.

### DIFF
--- a/testinfra/backend/base.py
+++ b/testinfra/backend/base.py
@@ -136,9 +136,10 @@ class BaseBackend(object):
             return command
 
     def get_command(self, command, *args):
+        command = self.quote(command, *args)
         if self.sudo:
             command = self.quote("sudo /bin/sh -c %s", command)
-        return self.quote(command, *args)
+        return command
 
     def run(self, command, *args, **kwargs):
         raise NotImplementedError

--- a/testinfra/test/integration/test_trusty.py
+++ b/testinfra/test/integration/test_trusty.py
@@ -67,7 +67,8 @@ def test_process(Process):
     assert ssh.comm == "sshd"
     assert ssh.euid == 0
 
-def test_command_parameter_quoting(File):
-    # Produces a grep command with a parameter which gets quoted since it has spaces
-    assert File('/etc/default/useradd').contains('^# Default values for useradd')
 
+def test_command_parameter_quoting(File):
+    # Produces a grep command with a parameter which gets quoted
+    # since it has spaces
+    assert File('/etc/default/useradd').contains('^# Default values for')

--- a/testinfra/test/integration/test_trusty.py
+++ b/testinfra/test/integration/test_trusty.py
@@ -66,3 +66,8 @@ def test_process(Process):
     assert ssh.args == "/usr/sbin/sshd -D"
     assert ssh.comm == "sshd"
     assert ssh.euid == 0
+
+def test_command_parameter_quoting(File):
+    # Produces a grep command with a parameter which gets quoted since it has spaces
+    assert File('/etc/default/useradd').contains('^# Default values for useradd')
+


### PR DESCRIPTION
Produced un-executable (even blocked the test run until ssh timeout) shell commands like this:

````sudo /bin/sh -c 'grep -qs -- '^first ' /tmp/testfile'````
