### PR TITLE
Added Python and Ruby package modules

### DIFF
--- a/testinfra/modules/__init__.py
+++ b/testinfra/modules/__init__.py
@@ -30,10 +30,13 @@ from testinfra.modules.socket import Socket
 from testinfra.modules.sysctl import Sysctl
 from testinfra.modules.systeminfo import SystemInfo
 from testinfra.modules.user import User
+from testinfra.modules.python_package import PythonPackage
+from testinfra.modules.ruby_package import RubyPackage
 
 
 __all__ = [
     "Command", "File", "Package", "Group", "Interface",
     "Service", "SystemInfo", "User", "Salt", "PuppetResource",
-    "Facter", "Sysctl", "Socket", "Ansible", "Process",
+    "Facter", "Sysctl", "Socket", "Ansible", "Process", "RubyPackage",
+    "PythonPackage",
 ]

--- a/testinfra/modules/python_package.py
+++ b/testinfra/modules/python_package.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+# Copyright © 2015 Philippe Pepiot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import unicode_literals
+
+import re
+
+from testinfra.modules.base import Module
+
+
+class PythonPackage(Module):
+    """Test status and version of Python package."""
+
+    def __init__(self, pkg_name, pip_path='pip'):
+        """
+        :param pkg_name: Name of the package to verify
+        :param pip_path: Path to the desired pip binary
+        """
+        super(PythonPackage, self).__init__()
+        self.pip_dict = {}
+        self.pkg_name = pkg_name
+        args = ['%s list', pip_path]
+        for line in self.check_output(*args).split('\n'):
+            py_re = re.compile('^([A-Za-z-_1-9]+) \((.*?)(, .*)\)$')
+            if re.match(py_re, line):
+                name, version = re.search(py_re, line).groups()[:2]
+                self.pip_dict[name] = version
+
+    @property
+    def is_installed(self):
+        return bool(self.pip_dict.get(self.pkg_name))
+
+    @property
+    def version(self):
+        return self.pip_dict.get(self.pkg_name)

--- a/testinfra/modules/ruby_package.py
+++ b/testinfra/modules/ruby_package.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+# Copyright © 2015 Philippe Pepiot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import unicode_literals
+
+import re
+
+from testinfra.modules.base import Module
+
+
+class RubyPackage(Module):
+    """Test status and version of Ruby gem"""
+
+    def __init__(self, pkg_name, gem_binary='gem'):
+        super(RubyPackage, self).__init__()
+        self.gem_dict = {}
+        self.pkg_name = pkg_name
+        args = ['%s list', gem_binary]
+        for line in self.check_output(*args).split('\n'):
+            gem_re = re.compile('^([A-Za-z-_1-9]+) \((.*?)\)$')
+            if re.match(gem_re, line):
+                name, version = re.search(gem_re, line).groups()
+                self.gem_dict[name] = version
+
+    @property
+    def is_installed(self):
+        return bool(self.gem_dict.get(self.pkg_name))
+
+    @property
+    def version(self):
+        return self.gem_dict.get(self.pkg_name)

--- a/testinfra/test/test_python_package.py
+++ b/testinfra/test/test_python_package.py
@@ -1,0 +1,51 @@
+import pytest
+from testinfra.modules.python_package import PythonPackage
+
+py_packages = """
+alabaster (0.7.7)
+Babel (2.2.0)
+decorator (4.0.9)
+docutils (0.12)
+imagesize (0.7.0)
+ipython (4.1.2)
+ipython-genutils (0.1.0)
+jedi (0.9.0)
+Jinja2 (2.8)
+MarkupSafe (0.23)
+path.py (8.1.2)
+pexpect (4.0.1)
+pickleshare (0.6)
+pip (8.0.2)
+ptyprocess (0.5.1)
+py (1.4.31)
+Pygments (2.1.3)
+pytest (2.9.1)
+pytz (2016.3)
+setuptools (19.6.2)
+simplegeneric (0.8.1)
+six (1.10.0)
+snowballstemmer (1.2.1)
+Sphinx (1.4)
+testinfra (1.1.1, /home/tmacey/code/mit/ops/testinfra)
+traitlets (4.2.1)
+wheel (0.26.0)
+"""
+
+@pytest.mark.parametrize('package,version', [
+    ('alabaster', '0.7.7'),
+    ('docutils', '0.12')
+])
+def test_python_package_installed(package, version, monkeypatch):
+    monkeypatch.setattr(PythonPackage, 'check_output',
+                        lambda *args: py_packages)
+    assert PythonPackage(package).is_installed
+    assert PythonPackage(package).version == version
+
+
+@pytest.mark.parametrize('package', [
+    ('requests'),
+])
+def test_python_package_not_installed(package, monkeypatch):
+    monkeypatch.setattr(PythonPackage, 'check_output',
+                        lambda *args: py_packages)
+    assert not PythonPackage(package).is_installed

--- a/testinfra/test/test_ruby_package.py
+++ b/testinfra/test/test_ruby_package.py
@@ -1,0 +1,36 @@
+import pytest
+from testinfra.modules.ruby_package import RubyPackage
+
+ruby_packages = """*** LOCAL GEMS ***
+
+bigdecimal (1.2.8)
+bundler (1.11.2)
+did_you_mean (1.0.0)
+io-console (0.4.5)
+json (1.8.3)
+minitest (5.8.3)
+net-telnet (0.1.1)
+power_assert (0.2.6)
+psych (2.0.17)
+rake (10.4.2)
+rdoc (4.2.1)
+test-unit (3.1.5)4"""
+
+@pytest.mark.parametrize('package,version', [
+    ('bundler', '1.11.2'),
+    ('minitest', '5.8.3')
+])
+def test_ruby_package_installed(package, version, monkeypatch):
+    monkeypatch.setattr(RubyPackage, 'check_output',
+                        lambda *args: ruby_packages)
+    assert RubyPackage(package).is_installed
+    assert RubyPackage(package).version == version
+
+
+@pytest.mark.parametrize('package', [
+    ('requests'),
+])
+def test_ruby_package_not_installed(package, monkeypatch):
+    monkeypatch.setattr(RubyPackage, 'check_output',
+                        lambda *args: ruby_packages)
+    assert not RubyPackage(package).is_installed


### PR DESCRIPTION
Added a module each for Python and Ruby package verification. Each
module exposes an `is_installed` and `version` property. They will each
accept an argument for the path to the preferred package manager binary
to use for determining which packages are installed.