### PR TITLE
Fixed the `coding` setting on source files

### DIFF
--- a/testinfra/__init__.py
+++ b/testinfra/__init__.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 # Copyright © 2015 Philippe Pepiot
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/testinfra/backend/__init__.py
+++ b/testinfra/backend/__init__.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 # Copyright © 2015 Philippe Pepiot
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/testinfra/backend/ansible.py
+++ b/testinfra/backend/ansible.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 # Copyright © 2015-2016 Philippe Pepiot
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/testinfra/backend/base.py
+++ b/testinfra/backend/base.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 # Copyright © 2015 Philippe Pepiot
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/testinfra/backend/docker.py
+++ b/testinfra/backend/docker.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 # Copyright © 2015 Philippe Pepiot
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/testinfra/backend/local.py
+++ b/testinfra/backend/local.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 # Copyright © 2015 Philippe Pepiot
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/testinfra/backend/paramiko.py
+++ b/testinfra/backend/paramiko.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 # Copyright © 2015-2016 Philippe Pepiot
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/testinfra/backend/salt.py
+++ b/testinfra/backend/salt.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 # Copyright © 2015 Philippe Pepiot
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/testinfra/backend/ssh.py
+++ b/testinfra/backend/ssh.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 # Copyright © 2015 Philippe Pepiot
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/testinfra/main.py
+++ b/testinfra/main.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 # Copyright © 2015 Philippe Pepiot
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/testinfra/modules/__init__.py
+++ b/testinfra/modules/__init__.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 # Copyright © 2015 Philippe Pepiot
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/testinfra/modules/ansible.py
+++ b/testinfra/modules/ansible.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 # Copyright © 2015 Philippe Pepiot
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/testinfra/modules/base.py
+++ b/testinfra/modules/base.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 # Copyright © 2015 Philippe Pepiot
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/testinfra/modules/command.py
+++ b/testinfra/modules/command.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 # Copyright © 2015 Philippe Pepiot
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/testinfra/modules/file.py
+++ b/testinfra/modules/file.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 # Copyright © 2015 Philippe Pepiot
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/testinfra/modules/group.py
+++ b/testinfra/modules/group.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 # Copyright © 2015 Philippe Pepiot
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/testinfra/modules/interface.py
+++ b/testinfra/modules/interface.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 # Copyright © 2015 Philippe Pepiot
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/testinfra/modules/package.py
+++ b/testinfra/modules/package.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 # Copyright © 2015 Philippe Pepiot
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/testinfra/modules/process.py
+++ b/testinfra/modules/process.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 # Copyright © 2015 Philippe Pepiot
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/testinfra/modules/puppet.py
+++ b/testinfra/modules/puppet.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 # Copyright © 2015 Philippe Pepiot
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/testinfra/modules/salt.py
+++ b/testinfra/modules/salt.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 # Copyright © 2015 Philippe Pepiot
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/testinfra/modules/service.py
+++ b/testinfra/modules/service.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 # Copyright © 2015 Philippe Pepiot
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/testinfra/modules/socket.py
+++ b/testinfra/modules/socket.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 # Copyright © 2015 Philippe Pepiot
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/testinfra/modules/sysctl.py
+++ b/testinfra/modules/sysctl.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 # Copyright © 2015 Philippe Pepiot
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/testinfra/modules/systeminfo.py
+++ b/testinfra/modules/systeminfo.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 # Copyright © 2015-2016 Philippe Pepiot
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/testinfra/modules/user.py
+++ b/testinfra/modules/user.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 # Copyright © 2015 Philippe Pepiot
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/testinfra/plugin.py
+++ b/testinfra/plugin.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 # Copyright © 2015 Philippe Pepiot
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/testinfra/test/integration/test_centos_7.py
+++ b/testinfra/test/integration/test_centos_7.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 # Copyright © 2015 Philippe Pepiot
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/testinfra/test/integration/test_fedora.py
+++ b/testinfra/test/integration/test_fedora.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 # Copyright © 2015 Philippe Pepiot
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/testinfra/test/integration/test_jessie.py
+++ b/testinfra/test/integration/test_jessie.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 # Copyright © 2015 Philippe Pepiot
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/testinfra/test/integration/test_trusty.py
+++ b/testinfra/test/integration/test_trusty.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 # Copyright © 2015 Philippe Pepiot
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/testinfra/test/integration/test_wheezy.py
+++ b/testinfra/test/integration/test_wheezy.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 # Copyright © 2015 Philippe Pepiot
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/testinfra/test/test_file.py
+++ b/testinfra/test/test_file.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 # Copyright © 2015 Philippe Pepiot
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/testinfra/test/test_socket.py
+++ b/testinfra/test/test_socket.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 # Copyright © 2015 Philippe Pepiot
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/testinfra/utils/ansible_runner.py
+++ b/testinfra/utils/ansible_runner.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 # Copyright © 2016 Philippe Pepiot
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/testinfra/utils/docker_compose_to_ssh_config.py
+++ b/testinfra/utils/docker_compose_to_ssh_config.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 # Copyright © 2016 Philippe Pepiot
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/testinfra/utils/ssh_config_to_ansible_inventory.py
+++ b/testinfra/utils/ssh_config_to_ansible_inventory.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 # Copyright © 2015-2016 Philippe Pepiot
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
The `coding` attribute was set to `utf8` which is not recognized as
being valid by Emacs, so I updated it to `utf-8` on all files.