### PR TITLE
Note that Socket module requires netstat

### DIFF
--- a/testinfra/modules/socket.py
+++ b/testinfra/modules/socket.py
@@ -69,6 +69,8 @@ class Socket(Module):
 
     ``socketspec`` must be specified as ``<protocol>://<host>:<port>``
 
+    This module requires the ``netstat`` command to on the target host.
+
     Example:
 
       - Unix sockets: ``unix:///var/run/docker.sock``


### PR DESCRIPTION
It's available in most places, but it might not be available in docker containers so add a clarifying note to the docs -- save someone a bit of time if they get this error:

```
ipdb> Socket("tcp://80").is_listening
*** Failed: Unexpected exit code 127 for CommandResult(command=b'netstat -n -l -t', exit_status=127, stdout=b'', stderr=b'/bin/sh: 1: netstat: not found\n')
```
