### PR TITLE
Added reference to ANSIBLE_REMOTE_USER

### DIFF
--- a/doc/source/backends.rst
+++ b/doc/source/backends.rst
@@ -81,4 +81,6 @@ The ansible backend use the `ansible python API
     $ testinfra --connection=ansible --hosts=host1,host2
     $ testinfra --connection=ansible --hosts='web*'
 
-You can use an alternative `inventory` with the ``--ansible-inventory`` option
+You can use an alternative `inventory` with the ``--ansible-inventory`` option.
+
+To use a different remote user, set the `$ANSIBLE_REMOTE_USER` environment variable: `$ export ANSIBLE_REMOTE_USER=<your-remote-user>`.

--- a/doc/source/backends.rst
+++ b/doc/source/backends.rst
@@ -83,4 +83,5 @@ The ansible backend use the `ansible python API
 
 You can use an alternative `inventory` with the ``--ansible-inventory`` option.
 
-To use a different remote user, set the `$ANSIBLE_REMOTE_USER` environment variable: `$ export ANSIBLE_REMOTE_USER=<your-remote-user>`.
+Note: Ansible settings such as ``remote_user``, etc., may be configured by using Ansible's
+`environment variables <http://docs.ansible.com/ansible/intro_configuration.html#environmental-configuration>`_.


### PR DESCRIPTION
I was struggling for a while to figure out how to set the username Ansible should use to connect. Rather than modifying the inventory / ansible.cfg as suggested in (here)[https://github.com/philpep/testinfra/issues/53], I thought it would make more sense to use one of Ansible's many [configurable environment variables](https://github.com/ansible/ansible/blob/devel/lib/ansible/constants.py).

I updated your backends doc to reflect that there is an environment variable one can use to control the remote user.

Any feedback / suggestions are gratefully accepted :).
