### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -15,7 +15,7 @@ all the tests pass *before* submitting your pull request. To run the complete
 test suite you must install:
 
 - `Docker <https://www.docker.com>`_
-- `tox <https://tox.readthedocs.org/en/latest/>`_
+- `tox <https://tox.readthedocs.io/en/latest/>`_
 
 To run all tests run::
 
@@ -34,7 +34,7 @@ Code style
 ==========
 
 Your code must pass without errors under `flake8
-<https://flake8.readthedocs.org>`_ with the extension `hacking
+<https://flake8.readthedocs.io>`_ with the extension `hacking
 <http://docs.openstack.org/developer/hacking/>`_::
 
 

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 Testinfra test your infrastructure
 ##################################
 
-Latest documentation: http://testinfra.readthedocs.org/en/latest
+Latest documentation: https://testinfra.readthedocs.io/en/latest
 
 About
 =====


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.