### PR TITLE
expand path when using --ssh-config

### DIFF
--- a/testinfra/backend/paramiko.py
+++ b/testinfra/backend/paramiko.py
@@ -59,7 +59,7 @@ class ParamikoBackend(base.BaseBackend):
             }
             if self.ssh_config:
                 ssh_config = paramiko.SSHConfig()
-                with open(self.ssh_config) as f:
+                with open(os.path.expanduser(self.ssh_config)) as f:
                     ssh_config.parse(f)
 
                 for key, value in ssh_config.lookup(self.host).items():


### PR DESCRIPTION
necesary to make the following work properly 
testinfra --connection=ssh --sudo --ssh-config=~/.ssh/config