### PR TITLE
Fix parallel execution with Salt backend

### DIFF
--- a/testinfra/backend/salt.py
+++ b/testinfra/backend/salt.py
@@ -80,6 +80,6 @@ class SaltBackend(base.BaseBackend):
             if not hosts:
                 raise RuntimeError("No host matching '%s'" % (host,))
             else:
-                return hosts
+                return sorted(hosts)
         else:
             return super(SaltBackend, cls).get_hosts(host, **kwargs)


### PR DESCRIPTION
Running tests in parallel with xdist used to fail with the Salt backend
because each worker would get a list of tests in a different order.

This commit ensures that the Salt backend returns hosts in a
deterministic order.