### PR TITLE
Check for presence of commands with command -v

### DIFF
--- a/images/centos_7/Dockerfile
+++ b/images/centos_7/Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:7
 
-RUN yum -y install openssh-server which && yum clean all &&\
+RUN yum -y install openssh-server && yum clean all &&\
     (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do if ! test $i = systemd-tmpfiles-setup.service; then rm -f $i; fi; done) && \
     rm -f /lib/systemd/system/multi-user.target.wants/* && \
     rm -f /etc/systemd/system/*.wants/* && \

--- a/images/fedora/Dockerfile
+++ b/images/fedora/Dockerfile
@@ -1,6 +1,6 @@
 FROM fedora:23
 
-RUN dnf -y install which procps python systemd openssh-server && dnf clean all &&\
+RUN dnf -y install procps python systemd openssh-server && dnf clean all &&\
     (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done) && \
     rm -f /lib/systemd/system/multi-user.target.wants/* && \
     rm -f /etc/systemd/system/*.wants/* && \

--- a/testinfra/modules/base.py
+++ b/testinfra/modules/base.py
@@ -35,7 +35,7 @@ class Module(object):
         return out
 
     def run_test(self, command, *args, **kwargs):
-        """Run command and check it return an exit status of 0 or 1
+        """Run command and check it return an exit status of 0, 1 or 127
 
         :raises: AssertionError
         """

--- a/testinfra/modules/base.py
+++ b/testinfra/modules/base.py
@@ -39,7 +39,7 @@ class Module(object):
 
         :raises: AssertionError
         """
-        return self.run_expect([0, 1], command, *args, **kwargs)
+        return self.run_expect([0, 1, 127], command, *args, **kwargs)
 
     def check_output(self, command, *args, **kwargs):
         """Get stdout of a command which has run successfully

--- a/testinfra/modules/package.py
+++ b/testinfra/modules/package.py
@@ -60,9 +60,9 @@ class Package(Module):
             return FreeBSDPackage
         elif SystemInfo.type in ("openbsd", "netbsd"):
             return OpenBSDPackage
-        elif Command.run_test("which dpkg-query").rc == 0:
+        elif Command.run_test("command -v dpkg-query").rc == 0:
             return DebianPackage
-        elif Command.run_test("which rpm").rc == 0:
+        elif Command.run_test("command -v rpm").rc == 0:
             return RpmPackage
         else:
             raise NotImplementedError

--- a/testinfra/modules/service.py
+++ b/testinfra/modules/service.py
@@ -51,11 +51,11 @@ class Service(Module):
         Command = _backend.get_module("Command")
         if SystemInfo.type == "linux":
             if (
-                Command.run_test("which systemctl").rc == 0
+                Command.run_test("command -v systemctl").rc == 0
                 and "systemd" in File("/sbin/init").linked_to
             ):
                 return SystemdService
-            elif Command.run_test("which initctl").rc == 0:
+            elif Command.run_test("command -v initctl").rc == 0:
                 return UpstartService
             else:
                 return SysvService

--- a/testinfra/test/conftest.py
+++ b/testinfra/test/conftest.py
@@ -45,7 +45,7 @@ check_output = _Command.check_output
 def has_docker():
     global _HAS_DOCKER
     if _HAS_DOCKER is None:
-        _HAS_DOCKER = _Command("which docker").rc == 0
+        _HAS_DOCKER = _Command("command -v docker").rc == 0
     return _HAS_DOCKER
 
 


### PR DESCRIPTION
I encountered an issue when trying to use the new [Amazon Linux container](https://docs.aws.amazon.com/AmazonECR/latest/userguide/amazon_linux_container_image.html) image as it does not come with the `which` command. 

The `which` command isn't always available, especially on more minimal Docker images.  A more POSIX compliant way of checking for the presence of commands is with `command -v`.