### PR TITLE
adding a release property to package module

### DIFF
--- a/testinfra/test/test_modules.py
+++ b/testinfra/test/test_modules.py
@@ -40,6 +40,18 @@ def test_package(docker_image, Package):
     }[docker_image]
     assert ssh.is_installed
     assert ssh.version.startswith(version)
+    release = {
+        "fedora": "6.fc",
+        "centos_7": "25.el7",
+        "debian_jessie": None,
+        "debian_wheezy": None,
+        "ubuntu_trusty": None,
+    }[docker_image]
+    if release is None:
+        with pytest.raises(NotImplementedError):
+            ssh.release
+    else:
+        assert ssh.release.startswith(release)
 
 
 def test_held_package(Package):


### PR DESCRIPTION
Hi

*Rationale*: I have found testinfra very useful for my work. But in my case, the relase info returned by RPM package manager is relevant for us.

This Pull Request adds an 'release' property to the Package module for package managers that support this property. Otherwise returns an `NotImplementedError` exception. This should not break any existing tests already written.

