### PR TITLE
fixed trailing LineFeed bug

### DIFF
--- a/testinfra/modules/base.py
+++ b/testinfra/modules/base.py
@@ -51,11 +51,7 @@ class Module(object):
         out = self.run(command, *args, **kwargs)
         if out.rc != 0:
             pytest.fail("Unexpected exit code %s for %s" % (out.rc, out))
-
-        if len(out.stdout) and out.stdout[-1] == "\n":
-            return out.stdout[:-1]
-        else:
-            return out.stdout
+        return out.stdout.rstrip("\r\n")
 
     @classmethod
     def get_module(cls, _backend):

--- a/testinfra/modules/systeminfo.py
+++ b/testinfra/modules/systeminfo.py
@@ -84,7 +84,7 @@ class SystemInfo(InstanceModule):
             "codename": None,
             "release": None,
         }
-        sysinfo["type"] = self.check_output("uname -s").lower().strip()
+        sysinfo["type"] = self.check_output("uname -s").lower()
         if sysinfo["type"] == "linux":
             sysinfo.update(**self._get_linux_sysinfo())
         else:

--- a/testinfra/modules/systeminfo.py
+++ b/testinfra/modules/systeminfo.py
@@ -84,7 +84,7 @@ class SystemInfo(InstanceModule):
             "codename": None,
             "release": None,
         }
-        sysinfo["type"] = self.check_output("uname -s").lower()
+        sysinfo["type"] = self.check_output("uname -s").lower().strip()
         if sysinfo["type"] == "linux":
             sysinfo.update(**self._get_linux_sysinfo())
         else:


### PR DESCRIPTION
I have detected that SystemInfo.type string got a hidden trailing CR.
A strip() gets away with this.
