### PR TITLE
Implementation for #155, expand User() to include gecos field

### DIFF
--- a/images/debian_jessie/Dockerfile
+++ b/images/debian_jessie/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && \
     echo "fr_FR.ISO-8859-15 ISO-8859-15" >> /etc/locale.gen && \
     locale-gen && \
     update-locale && \
-    useradd -m user && \
+    useradd -m user -c "gecos.comment" && \
     adduser user sudo && \
     echo "user ALL=NOPASSWD: ALL" > /etc/sudoers.d/user && \
     mkdir -p /root/.ssh && \

--- a/testinfra/modules/user.py
+++ b/testinfra/modules/user.py
@@ -82,6 +82,16 @@ class User(Module):
         return self.check_output("getent shadow %s", self.name).split(":")[1]
 
     @property
+    def comment(self):
+        """Return the user comment/gecos field"""
+        return self.check_output("getent passwd %s", self.name).split(":")[4]
+
+    @property
+    def gecos(self):
+        """Same as comment, but gecos is the actual name (see 'man 5 getpwent')"""
+        return self.comment()
+
+    @property
     def expiration_date(self):
         """Return the account expiration date
 

--- a/testinfra/modules/user.py
+++ b/testinfra/modules/user.py
@@ -82,14 +82,9 @@ class User(Module):
         return self.check_output("getent shadow %s", self.name).split(":")[1]
 
     @property
-    def comment(self):
+    def gecos(self):
         """Return the user comment/gecos field"""
         return self.check_output("getent passwd %s", self.name).split(":")[4]
-
-    @property
-    def gecos(self):
-        """Same as comment, gecos is the actual name (see 'man getpwent')"""
-        return self.comment()
 
     @property
     def expiration_date(self):

--- a/testinfra/modules/user.py
+++ b/testinfra/modules/user.py
@@ -88,7 +88,7 @@ class User(Module):
 
     @property
     def gecos(self):
-        """Same as comment, but gecos is the actual name (see 'man 5 getpwent')"""
+        """Same as comment, gecos is the actual name (see 'man 5 getpwent')"""
         return self.comment()
 
     @property

--- a/testinfra/modules/user.py
+++ b/testinfra/modules/user.py
@@ -88,7 +88,7 @@ class User(Module):
 
     @property
     def gecos(self):
-        """Same as comment, gecos is the actual name (see 'man 5 getpwent')"""
+        """Same as comment, gecos is the actual name (see 'man getpwent')"""
         return self.comment()
 
     @property

--- a/testinfra/test/test_modules.py
+++ b/testinfra/test/test_modules.py
@@ -206,6 +206,12 @@ def test_user(User):
     assert user.password == "*"
 
 
+def test_user_user(User):
+    user = User("user")
+    assert user.exists
+    assert user.gecos == "gecos.comment"
+
+
 def test_user_expiration_date(User):
     assert User("root").expiration_date is None
     assert User("user").expiration_date == datetime.datetime(2024, 10, 4, 0, 0)


### PR DESCRIPTION
Issue #155 requested access to the comment (called the gecos field for historical reasons, see 'man 5 passwd' and 'man getpwent').

Very simple change that built upon the code that was already there.
