### PR TITLE
single fixture 'host'

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,22 +27,22 @@ Install testinfra using pip::
 
 Write your first tests file to `test_myinfra.py`::
 
-    def test_passwd_file(File):
-        passwd = File("/etc/passwd")
+    def test_passwd_file(host):
+        passwd = host.file("/etc/passwd")
         assert passwd.contains("root")
         assert passwd.user == "root"
         assert passwd.group == "root"
         assert passwd.mode == 0o644
 
 
-    def test_nginx_is_installed(Package):
-        nginx = Package("nginx")
+    def test_nginx_is_installed(host):
+        nginx = host.package("nginx")
         assert nginx.is_installed
         assert nginx.version.startswith("1.2")
 
 
-    def test_nginx_running_and_enabled(Service):
-        nginx = Service("nginx")
+    def test_nginx_running_and_enabled(host):
+        nginx = host.service("nginx")
         assert nginx.is_running
         assert nginx.is_enabled
 

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -7,20 +7,18 @@ Connection API
 ~~~~~~~~~~~~~~
 
 You can use testinfra outside of pytest or you can dynamically get a
-connection and call fonction from modules::
+`host` and call fonction from modules::
 
     >>> import testinfra
-    >>> conn = testinfra.get_backend("paramiko://root@server:2222", sudo=True)
-    >>> conn.File("/etc/shadow").mode == 0o640
+    >>> host = testinfra.get_host("paramiko://root@server:2222", sudo=True)
+    >>> host.file("/etc/shadow").mode == 0o640
     True
-
-Same applies to all :ref:`modules`.
 
 For instance you could make a test to compare two files on two different servers::
 
     import testinfra
 
     def test_same_passwd():
-        a = testinfra.get_backend("ssh://a")
-        b = testinfra.get_backend("ssh://b")
-        assert a.File("/etc/passwd").content == a.File("/etc/passwd").content
+        a = testinfra.get_host("ssh://a")
+        b = testinfra.get_host("ssh://b")
+        assert a.file("/etc/passwd").content == b.file("/etc/passwd").content

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -88,7 +88,7 @@ exclude_patterns = []
 
 # If true, the current module name will be prepended to all description
 # unit titles (such as .. function::).
-# add_module_names = True
+add_module_names = False
 
 # If true, sectionauthor and moduleauthor directives will be shown in the
 # output. They are ignored by default.

--- a/doc/source/invocation.rst
+++ b/doc/source/invocation.rst
@@ -31,7 +31,7 @@ You can also set hosts per test module::
 
     testinfra_hosts = ["localhost", "root@webserver:2222"]
 
-    def test_foo(File, Package, Service):
+    def test_foo(host):
         [....]
 
 

--- a/doc/source/modules.rst
+++ b/doc/source/modules.rst
@@ -3,40 +3,102 @@
 Modules
 =======
 
-Testinfra modules are provided as `pytest fixtures`_, declare them as
-arguments of your test function to make them available::
+Testinfra modules are provided through the `host` `fixture`_, declare it as
+arguments of your test function to make it available within it.
 
-    def test_foo(Package, File, Command):
-        [...]
+.. code-block:: python
 
-
-Note that you can also :ref:`make modules`.
-
-Command
-~~~~~~~
-
-.. autoclass:: testinfra.modules.command.Command(command, *args)
-   :members: check_output, run_expect, run_test, exists
+    def test_foo(host):
+        # [...]
 
 
-LocalCommand
-~~~~~~~~~~~~
-
-
-.. autofunction:: testinfra.plugin.LocalCommand(command, *args)
-
-
-TestinfraBackend
-~~~~~~~~~~~~~~~~
-
-.. autoclass:: testinfra.backend.base.BaseBackend()
-   :members:
-
-
-Sudo
+host
 ~~~~
 
-.. autoclass:: testinfra.modules.sudo.Sudo(user=None)
+.. autoclass:: testinfra.host.Host
+   :members:
+   :member-order: run
+
+    .. attribute:: ansible
+
+       :class:`testinfra.modules.ansible.Ansible` class
+
+    .. attribute:: file
+
+       :class:`testinfra.modules.file.File` class
+
+    .. attribute:: group
+
+       :class:`testinfra.modules.group.Group` class
+
+    .. attribute:: interface
+
+       :class:`testinfra.modules.interface.Interface` class
+
+    .. attribute:: mount_point
+
+       :class:`testinfra.modules.mountpoint.MountPoint` class
+
+    .. attribute:: package
+
+       :class:`testinfra.modules.package.Package` class
+
+    .. attribute:: pip_package
+
+       :class:`testinfra.modules.pip.PipPackage` class
+
+    .. attribute:: process
+
+       :class:`testinfra.modules.process.Process` class
+
+    .. attribute:: puppet_resource
+
+       :class:`testinfra.modules.puppet.PuppetResource` class
+
+    .. attribute:: facter
+
+       :class:`testinfra.modules.puppet.Facter` class
+
+    .. attribute:: salt
+
+       :class:`testinfra.modules.salt.Salt` class
+
+    .. attribute:: service
+
+       :class:`testinfra.modules.service.Service` class
+
+    .. attribute:: socket
+
+       :class:`testinfra.modules.socket.Socket` class
+
+    .. attribute:: sudo
+
+       :class:`testinfra.modules.sudo.Sudo` class
+
+    .. attribute:: supervisor
+
+       :class:`testinfra.modules.supervisor.Supervisor` class
+
+    .. attribute:: sysctl
+
+       :class:`testinfra.modules.sysctl.Sysctl` class
+
+    .. attribute:: system_info
+
+       :class:`testinfra.modules.systeminfo.SystemInfo` class
+
+    .. attribute:: user
+
+       :class:`testinfra.modules.user.User` class
+
+
+
+
+Ansible
+~~~~~~~
+
+.. autoclass:: testinfra.modules.ansible.Ansible(module_name, module_args=None, check=True)
+   :members:
 
 
 File
@@ -46,14 +108,6 @@ File
    :members:
    :undoc-members:
    :exclude-members: get_module_class
-
-
-User
-~~~~
-
-.. autoclass:: testinfra.modules.user.User
-   :members:
-   :undoc-members:
 
 
 Group
@@ -73,6 +127,13 @@ Interface
    :exclude-members: get_module_class
 
 
+MountPoint
+~~~~~~~~~~
+
+.. autoclass:: testinfra.modules.mountpoint.MountPoint(path)
+   :members:
+
+
 Package
 ~~~~~~~
 
@@ -86,23 +147,39 @@ PipPackage
 .. autoclass:: testinfra.modules.pip.PipPackage
    :members:
 
+
 Process
 ~~~~~~~
 
 .. autoclass:: testinfra.modules.process.Process
    :members:
 
+
+PuppetResource
+~~~~~~~~~~~~~~
+
+.. autoclass:: testinfra.modules.puppet.PuppetResource(type, name=None)
+   :members:
+
+
+Facter
+~~~~~~
+
+.. autoclass:: testinfra.modules.puppet.Facter(*facts)
+   :members:
+
+
+Salt
+~~~~
+
+.. autoclass:: testinfra.modules.salt.Salt(function, args=None)
+   :members:
+
+
 Service
 ~~~~~~~
 
 .. autoclass:: testinfra.modules.service.Service
-   :members:
-
-
-Supervisor
-~~~~~~~~~~
-
-.. autoclass:: testinfra.modules.supervisor.Supervisor
    :members:
 
 
@@ -113,42 +190,18 @@ Socket
    :members:
 
 
-SystemInfo
-~~~~~~~~~~
-
-
-.. autoclass:: testinfra.modules.systeminfo.SystemInfo
-   :members:
-
-
-Salt
+Sudo
 ~~~~
 
+.. autoclass:: testinfra.modules.sudo.Sudo(user=None)
 
-.. autoclass:: testinfra.modules.salt.Salt(function, args=None)
+
+Supervisor
+~~~~~~~~~~
+
+.. autoclass:: testinfra.modules.supervisor.Supervisor
    :members:
 
-Ansible
-~~~~~~~
-
-.. autoclass:: testinfra.modules.ansible.Ansible(module_name, module_args=None, check=True)
-   :members:
-
-
-PuppetResource
-~~~~~~~~~~~~~~
-
-
-.. autoclass:: testinfra.modules.puppet.PuppetResource(type, name=None)
-   :members:
-
-
-Facter
-~~~~~~
-
-
-.. autoclass:: testinfra.modules.puppet.Facter(*facts)
-   :members:
 
 Sysctl
 ~~~~~~
@@ -157,10 +210,19 @@ Sysctl
    :members:
 
 
-MountPoint
+SystemInfo
 ~~~~~~~~~~
 
-.. autoclass:: testinfra.modules.mountpoint.MountPoint(path)
+.. autoclass:: testinfra.modules.systeminfo.SystemInfo
    :members:
 
-.. _pytest fixtures: https://pytest.org/latest/fixture.html
+
+User
+~~~~
+
+.. autoclass:: testinfra.modules.user.User
+   :members:
+   :undoc-members: get_module_class
+
+
+.. _fixture: https://docs.pytest.org/en/latest/fixture.html#fixture

--- a/pylintrc
+++ b/pylintrc
@@ -12,6 +12,7 @@ max-bool-expr=6
 max-args=8
 # we have flake8 for that
 max-line-length=1000
+generated-members=check_output,run_test,run_expect,run
 
 [REPORTS]
 reports=no

--- a/testinfra/__init__.py
+++ b/testinfra/__init__.py
@@ -13,24 +13,19 @@
 
 from __future__ import unicode_literals
 
-from testinfra import backend
+import warnings
 
-__all__ = ["get_backend", "get_backends"]
-
-
-_BACKEND_CACHE = {}
-_BACKENDS_CACHE = {}
+from testinfra.host import get_host
+from testinfra.host import get_hosts
 
 
 def get_backend(hostspec, **kwargs):
-    key = (hostspec, frozenset(kwargs.items()))
-    if key not in _BACKEND_CACHE:
-        _BACKEND_CACHE[key] = backend.get_backend(hostspec, **kwargs)
-    return _BACKEND_CACHE[key]
+    warnings.warn("get_backend() is deprecated, use get_host() instead",
+                  DeprecationWarning, stacklevel=2)
+    return get_host(hostspec, **kwargs).backend
 
 
 def get_backends(hosts, **kwargs):
-    key = (frozenset(hosts), frozenset(kwargs.items()))
-    if key not in _BACKENDS_CACHE:
-        _BACKENDS_CACHE[key] = backend.get_backends(hosts, **kwargs)
-    return _BACKENDS_CACHE[key]
+    warnings.warn("get_backends() is deprecated, use get_hosts() instead",
+                  DeprecationWarning, stacklevel=2)
+    return [host.backend for host in get_hosts(hosts, **kwargs)]

--- a/testinfra/backend/__init__.py
+++ b/testinfra/backend/__init__.py
@@ -66,8 +66,7 @@ def get_backend(hostspec, **kwargs):
     klass = get_backend_class(kw["connection"])
     if kw["connection"] == "local":
         return klass(**kw)
-    else:
-        return klass(host, **kw)
+    return klass(host, **kw)
 
 
 def get_backends(hosts, **kwargs):

--- a/testinfra/backend/ansible.py
+++ b/testinfra/backend/ansible.py
@@ -39,7 +39,7 @@ class AnsibleBackend(base.BaseBackend):
             self._ansible_runner = AnsibleRunner(self.ansible_inventory)
         return self._ansible_runner
 
-    def run(self, command, *args):
+    def run(self, command, *args, **kwargs):
         command = self.get_command(command, *args)
         out = self.run_ansible("shell", module_args=command)
 

--- a/testinfra/backend/base.py
+++ b/testinfra/backend/base.py
@@ -148,15 +148,13 @@ class BaseBackend(object):
     def quote(command, *args):
         if args:
             return command % tuple(pipes.quote(a) for a in args)
-        else:
-            return command
+        return command
 
     def get_sudo_command(self, command, sudo_user):
         if sudo_user is None:
             return self.quote("sudo /bin/sh -c %s", command)
-        else:
-            return self.quote(
-                "sudo -u %s /bin/sh -c %s", sudo_user, command)
+        return self.quote(
+            "sudo -u %s /bin/sh -c %s", sudo_user, command)
 
     def get_command(self, command, *args):
         command = self.quote(command, *args)

--- a/testinfra/backend/base.py
+++ b/testinfra/backend/base.py
@@ -17,8 +17,10 @@ import locale
 import logging
 import pipes
 import subprocess
+import warnings
 
 import testinfra.modules
+import testinfra.utils
 
 logger = logging.getLogger("testinfra")
 
@@ -86,11 +88,14 @@ class BaseBackend(object):
 
     def __init__(self, hostname, sudo=False, sudo_user=None, *args, **kwargs):
         self._encoding = None
-        self._module_cache = {}
+        self._host = None
         self.hostname = hostname
         self.sudo = sudo
         self.sudo_user = sudo_user
         super(BaseBackend, self).__init__()
+
+    def set_host(self, host):
+        self._host = host
 
     @classmethod
     def get_connection_type(cls):
@@ -231,25 +236,14 @@ class BaseBackend(object):
         logger.info("RUN %s", result)
         return result
 
-    def __getattr__(self, attr):
-        return self.get_module(attr)
+    def __getattr__(self, name):
+        warnings.warn('get_module() is deprecated, use new host API',
+                      DeprecationWarning, stacklevel=2)
+        module = getattr(self._host, testinfra.utils.un_camel_case(name))
+        setattr(self, name, module)
+        return module
 
     def get_module(self, name):
-        """Return the testinfra module adapted to the current backend
-
-        ::
-
-            def test(Package):
-                [...]
-
-            # Is equivalent to
-            def test(TestinfraBackend):
-                Package = TestinfraBackend.get_module("Package")
-
-        """
-        try:
-            module = self._module_cache[name]
-        except KeyError:
-            module = testinfra.modules.get_module_class(name).get_module(self)
-            self._module_cache[name] = module
-        return module
+        warnings.warn('get_module() is deprecated, use new host API',
+                      DeprecationWarning, stacklevel=2)
+        return getattr(self, name)

--- a/testinfra/backend/salt.py
+++ b/testinfra/backend/salt.py
@@ -38,7 +38,7 @@ class SaltBackend(base.BaseBackend):
             self._client = salt.client.LocalClient()
         return self._client
 
-    def run(self, command, *args):
+    def run(self, command, *args, **kwargs):
         command = self.get_command(command, *args)
         out = self.run_salt("cmd.run_all", [command])
         return self.result(out['retcode'], command, out['stdout'],

--- a/testinfra/host.py
+++ b/testinfra/host.py
@@ -1,0 +1,133 @@
+# coding: utf-8
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import unicode_literals
+
+import testinfra.backend
+import testinfra.modules
+
+
+class Host(object):
+    _host_cache = {}
+    _hosts_cache = {}
+
+    def __init__(self, backend):
+        self.backend = backend
+        super(Host, self).__init__()
+
+    def exists(self, command):
+        """Return True if given command exist in $PATH"""
+        return self.run_expect([0, 1, 127], "command -v %s", command).rc == 0
+
+    def run(self, command, *args, **kwargs):
+        """Run given command and return rc (exit status), stdout and stderr
+
+        >>> cmd = host.run("ls -l /etc/passwd")
+        >>> cmd.rc
+        0
+        >>> cmd.stdout
+        '-rw-r--r-- 1 root root 1790 Feb 11 00:28 /etc/passwd\\n'
+        >>> cmd.stderr
+        ''
+
+
+        Good practice: always use shell arguments quoting to avoid shell
+        injection
+
+
+        >>> cmd = host.run("ls -l -- %s", "/;echo inject")
+        CommandResult(
+            rc=2, stdout='',
+            stderr=(
+              'ls: cannot access /;echo inject: No such file or directory\\n'),
+            command="ls -l '/;echo inject'")
+        """
+        return self.backend.run(command, *args, **kwargs)
+
+    def run_expect(self, expected, command, *args, **kwargs):
+        """Run command and check it return an expected exit status
+
+        :param expected: A list of expected exit status
+        :raises: AssertionError
+        """
+        __tracebackhide__ = True  # pylint: disable=unused-variable
+        out = self.run(command, *args, **kwargs)
+        assert out.rc in expected, (
+            'Unexpected exit code %s for %s' % (out.rc, out))
+        return out
+
+    def run_test(self, command, *args, **kwargs):
+        """Run command and check it return an exit status of 0 or 1
+
+        :raises: AssertionError
+        """
+        return self.run_expect([0, 1], command, *args, **kwargs)
+
+    def check_output(self, command, *args, **kwargs):
+        """Get stdout of a command which has run successfully
+
+        :returns: stdout without trailing newline
+        :raises: AssertionError
+        """
+        __tracebackhide__ = True  # pylint: disable=unused-variable
+        out = self.run(command, *args, **kwargs)
+        assert out.rc == 0, (
+            'Unexpected exit code %s for %s' % (out.rc, out))
+        return out.stdout.rstrip("\r\n")
+
+    def __getattr__(self, name):
+        assert name in testinfra.modules.modules, name + " is not a module"
+        module_class = testinfra.modules.get_module_class(name)
+        obj = module_class.get_module(self.backend)
+        setattr(self, name, obj)
+        return obj
+
+    @classmethod
+    def get_host(cls, hostspec, **kwargs):
+        """Return a Host instance from `hostspec`
+
+        `hostspec` should be like
+        `<backend_type>://<name>?param1=value1&param2=value2`
+
+        Params can also be passed in `**kwargs` (eg. get_host("local://",
+        sudo=True) is equivalent to get_host("local://?sudo=true"))
+
+        Examples::
+
+        >>> get_host("local://", sudo=True)
+        >>> get_host("paramiko://user@host", ssh_config="/path/my_ssh_config")
+        >>> get_host("ansible://all?ansible_inventory=/etc/ansible/inventory")
+        """
+        key = (hostspec, frozenset(kwargs.items()))
+        cache = cls._host_cache
+        if key not in cache:
+            backend = testinfra.backend.get_backend(hostspec, **kwargs)
+            cache[key] = host = cls(backend)
+            backend.set_host(host)
+        return cache[key]
+
+    @classmethod
+    def get_hosts(cls, hosts, **kwargs):
+        key = (frozenset(hosts), frozenset(kwargs.items()))
+        cache = cls._hosts_cache
+        if key not in cache:
+            cache[key] = []
+            for backend in testinfra.backend.get_backends(hosts, **kwargs):
+                host = cls(backend)
+                backend.set_host(host)
+                cache[key].append(host)
+        return cache[key]
+
+
+get_host = Host.get_host
+get_hosts = Host.get_hosts

--- a/testinfra/main.py
+++ b/testinfra/main.py
@@ -94,5 +94,4 @@ def main():
         out.seek(0)
         shutil.copyfileobj(out, sys.stdout)
         return ret
-    else:
-        return pytest.main()
+    return pytest.main()

--- a/testinfra/modules/__init__.py
+++ b/testinfra/modules/__init__.py
@@ -15,30 +15,33 @@ from __future__ import unicode_literals
 
 import importlib
 
+import testinfra.utils
+
 modules = {
-    'Ansible': 'ansible:Ansible',
-    'Command': 'command:Command',
-    'File': 'file:File',
-    'Group': 'group:Group',
-    'Interface': 'interface:Interface',
-    'MountPoint': 'mountpoint:MountPoint',
-    'Package': 'package:Package',
-    'PipPackage': 'pip:PipPackage',
-    'Process': 'process:Process',
-    'PuppetResource': 'puppet:PuppetResource',
-    'Facter': 'puppet:Facter',
-    'Salt': 'salt:Salt',
-    'Service': 'service:Service',
-    'Socket': 'socket:Socket',
-    'Sudo': 'sudo:Sudo',
-    'Supervisor': 'supervisor:Supervisor',
-    'Sysctl': 'sysctl:Sysctl',
-    'SystemInfo': 'systeminfo:SystemInfo',
-    'User': 'user:User',
+    'ansible': 'ansible:Ansible',
+    'command': 'command:Command',
+    'file': 'file:File',
+    'group': 'group:Group',
+    'interface': 'interface:Interface',
+    'mount_point': 'mountpoint:MountPoint',
+    'package': 'package:Package',
+    'pip_package': 'pip:PipPackage',
+    'process': 'process:Process',
+    'puppet_resource': 'puppet:PuppetResource',
+    'facter': 'puppet:Facter',
+    'salt': 'salt:Salt',
+    'service': 'service:Service',
+    'socket': 'socket:Socket',
+    'sudo': 'sudo:Sudo',
+    'supervisor': 'supervisor:Supervisor',
+    'sysctl': 'sysctl:Sysctl',
+    'system_info': 'systeminfo:SystemInfo',
+    'user': 'user:User',
 }
 
 
 def get_module_class(name):
+    name = testinfra.utils.un_camel_case(name)
     modname, classname = modules[name].split(':')
     modname = '.'.join([__name__, modname])
     module = importlib.import_module(modname)

--- a/testinfra/modules/ansible.py
+++ b/testinfra/modules/ansible.py
@@ -25,8 +25,8 @@ class AnsibleException(Exception):
     result from ansible can be accessed through the ``result`` attribute
 
     >>> try:
-    ...     Ansible("command", "echo foo")
-    ... except Ansible.AnsibleException as exc:
+    ...     host.ansible("command", "echo foo")
+    ... except host.ansible.AnsibleException as exc:
     ...     assert exc.result['failed'] is True
     ...     assert exc.result['msg'] == 'check mode not supported for command'
     """
@@ -47,24 +47,24 @@ class Ansible(InstanceModule):
     <https://docs.ansible.com/ansible/playbooks_checkmode.html>`_ is
     enabled by default, you can disable it with `check=False`.
 
-    >>> Ansible("apt", "name=nginx state=present")["changed"]
+    >>> host.ansible("apt", "name=nginx state=present")["changed"]
     False
-    >>> Ansible("command", "echo foo", check=False)["stdout"]
+    >>> host.ansible("command", "echo foo", check=False)["stdout"]
     'foo'
-    >>> Ansible("setup")["ansible_facts"]["ansible_lsb"]["codename"]
+    >>> host.ansible("setup")["ansible_facts"]["ansible_lsb"]["codename"]
     'jessie'
-    >>> Ansible("file", "path=/etc/passwd")["mode"]
+    >>> host.ansible("file", "path=/etc/passwd")["mode"]
     '0640'
 
     """
     AnsibleException = AnsibleException
 
     def __call__(self, module_name, module_args=None, check=True, **kwargs):
-        if not self._backend.HAS_RUN_ANSIBLE:
+        if not self._host.backend.HAS_RUN_ANSIBLE:
             raise RuntimeError((
                 "Ansible module is only available with ansible "
                 "connection backend"))
-        result = self._backend.run_ansible(
+        result = self._host.backend.run_ansible(
             module_name, module_args, check=check, **kwargs)
         if result.get("failed", False) is True:
             raise AnsibleException(result)
@@ -73,7 +73,7 @@ class Ansible(InstanceModule):
     def get_variables(self):
         """Returns a dict of ansible variables
 
-        >>> Ansible.get_variables()
+        >>> host.ansible.get_variables()
         {
             'inventory_hostname': 'localhost',
             'group_names': ['ungrouped'],
@@ -81,7 +81,7 @@ class Ansible(InstanceModule):
         }
 
         """
-        return self._backend.get_variables()
+        return self._host.backend.get_variables()
 
     def __repr__(self):
         return "<ansible>"

--- a/testinfra/modules/base.py
+++ b/testinfra/modules/base.py
@@ -15,57 +15,27 @@ from __future__ import unicode_literals
 
 
 class Module(object):
-    _backend = None
-
-    def run(self, command, *args, **kwargs):
-        return self._backend.run(command, *args, **kwargs)
-
-    def run_expect(self, expected, command, *args, **kwargs):
-        """Run command and check it return an expected exit status
-
-        :param expected: A list of expected exit status
-        :raises: AssertionError
-        """
-        __tracebackhide__ = True  # pylint: disable=unused-variable
-        out = self.run(command, *args, **kwargs)
-        assert out.rc in expected, (
-            'Unexpected exit code %s for %s' % (out.rc, out))
-        return out
-
-    def run_test(self, command, *args, **kwargs):
-        """Run command and check it return an exit status of 0 or 1
-
-        :raises: AssertionError
-        """
-        return self.run_expect([0, 1], command, *args, **kwargs)
-
-    def check_output(self, command, *args, **kwargs):
-        """Get stdout of a command which has run successfully
-
-        :returns: stdout without trailing newline
-        :raises: AssertionError
-        """
-        __tracebackhide__ = True  # pylint: disable=unused-variable
-        out = self.run(command, *args, **kwargs)
-        assert out.rc == 0, (
-            'Unexpected exit code %s for %s' % (out.rc, out))
-        return out.stdout.rstrip("\r\n")
+    _host = None
 
     @classmethod
-    def get_module(cls, _backend):
-        klass = cls.get_module_class(_backend)
+    def get_module(cls, _host):
+        klass = cls.get_module_class(_host)
         return type(klass.__name__, (klass,), {
-            "_backend": _backend,
+            "_host": _host,
+            "run": _host.run,
+            "run_expect": _host.run_expect,
+            "run_test": _host.run_test,
+            "check_output": _host.check_output,
         })
 
     @classmethod
-    def get_module_class(cls, _backend):
+    def get_module_class(cls, host):
         return cls
 
 
 class InstanceModule(Module):
 
     @classmethod
-    def get_module(cls, _backend):
-        klass = super(InstanceModule, cls).get_module(_backend)
+    def get_module(cls, _host):
+        klass = super(InstanceModule, cls).get_module(_host)
         return klass()

--- a/testinfra/modules/command.py
+++ b/testinfra/modules/command.py
@@ -17,33 +17,12 @@ from testinfra.modules.base import InstanceModule
 
 
 class Command(InstanceModule):
-    """Run given command and return rc (exit status), stdout and stderr
-
-    >>> cmd = Command("ls -l /etc/passwd")
-    >>> cmd.rc
-    0
-    >>> cmd.stdout
-    '-rw-r--r-- 1 root root 1790 Feb 11 00:28 /etc/passwd\\n'
-    >>> cmd.stderr
-    ''
-
-
-    Good practice: always use shell arguments quoting to avoid shell injection
-
-
-    >>> cmd = Command("ls -l -- %s", "/;echo inject")
-    CommandResult(
-        rc=2, stdout='',
-        stderr='ls: cannot access /;echo inject: No such file or directory\\n',
-        command="ls -l '/;echo inject'")
-    """
 
     def __call__(self, command, *args, **kwargs):
         return self.run(command, *args, **kwargs)
 
     def exists(self, command):
-        """Return True if given command exist in $PATH"""
-        return self.run_expect([0, 1, 127], "command -v %s", command).rc == 0
+        return self._host.exists(command)
 
     def __repr__(self):
         return "<command>"

--- a/testinfra/modules/file.py
+++ b/testinfra/modules/file.py
@@ -29,9 +29,9 @@ class File(Module):
     def exists(self):
         """Test if file exists
 
-        >>> File("/etc/passwd").exists
+        >>> host.file("/etc/passwd").exists
         True
-        >>> File("/nonexistent").exists
+        >>> host.file("/nonexistent").exists
         False
 
         """
@@ -61,7 +61,7 @@ class File(Module):
     def linked_to(self):
         """Resolve symlink
 
-        >>> File("/var/lock").linked_to
+        >>> host.file("/var/lock").linked_to
         '/run/lock'
         """
         return self.check_output("readlink -f %s", self.path)
@@ -70,7 +70,7 @@ class File(Module):
     def user(self):
         """Return file owner as string
 
-        >>> File("/etc/passwd").user
+        >>> host.file("/etc/passwd").user
         'root'
         """
         raise NotImplementedError
@@ -79,7 +79,7 @@ class File(Module):
     def uid(self):
         """Return file user id as integer
 
-        >>> File("/etc/passwd").uid
+        >>> host.file("/etc/passwd").uid
         0
         """
         raise NotImplementedError
@@ -96,11 +96,11 @@ class File(Module):
     def mode(self):
         """Return file mode as octal integer
 
-        >>> File("/etc/passwd").mode
+        >>> host.file("/etc/passwd").mode
         384  # 0o600 (octal)
-        >>> File("/etc/password").mode == 0o600
+        >>> host.file("/etc/password").mode == 0o600
         True
-        >>> oct(File("/etc/password").mode) == '0600'
+        >>> oct(host.file("/etc/password").mode) == '0600'
         True
 
         Note: Python 3 oct(x)_ function will produce ``'0o600'``
@@ -109,7 +109,7 @@ class File(Module):
         the stat_ library for testing file mode.
 
         >>> import stat
-        >>> File("/etc/password").mode == stat.S_IRUSR | stat.S_IWUSR
+        >>> host.file("/etc/password").mode == stat.S_IRUSR | stat.S_IWUSR
         True
 
         .. _oct(x): https://docs.python.org/3.5/library/functions.html#oct
@@ -141,7 +141,7 @@ class File(Module):
     def content(self):
         """Return file content as bytes
 
-        >>> File("/tmp/foo").content
+        >>> host.file("/tmp/foo").content
         b'caf\\xc3\\xa9'
         """
         return self._get_content(False)
@@ -150,7 +150,7 @@ class File(Module):
     def content_string(self):
         """Return file content as string
 
-        >>> File("/tmp/foo").content_string
+        >>> host.file("/tmp/foo").content_string
         'café'
         """
         return self._get_content(True)
@@ -159,7 +159,7 @@ class File(Module):
     def mtime(self):
         """Return time of last modification as datetime.datetime object
 
-        >>> File("/etc/passwd").mtime
+        >>> host.file("/etc/passwd").mtime
         datetime.datetime(2015, 3, 15, 20, 25, 40)
         """
         raise NotImplementedError
@@ -173,13 +173,13 @@ class File(Module):
         return "<file %s>" % (self.path,)
 
     @classmethod
-    def get_module_class(cls, _backend):
-        SystemInfo = _backend.get_module("SystemInfo")
-        if SystemInfo.type == "linux":
+    def get_module_class(cls, host):
+        if host.system_info.type == "linux":
             return GNUFile
-        elif SystemInfo.type == "netbsd":
+        elif host.system_info.type == "netbsd":
             return NetBSDFile
-        elif SystemInfo.type.endswith("bsd") or SystemInfo.type == "darwin":
+        elif (host.system_info.type.endswith("bsd")
+                or host.system_info.type == "darwin"):
             return BSDFile
         else:
             raise NotImplementedError

--- a/testinfra/modules/file.py
+++ b/testinfra/modules/file.py
@@ -134,8 +134,7 @@ class File(Module):
             raise RuntimeError("Unexpected output %s" % (out,))
         if decode:
             return out.stdout
-        else:
-            return out.stdout_bytes
+        return out.stdout_bytes
 
     @property
     def content(self):

--- a/testinfra/modules/interface.py
+++ b/testinfra/modules/interface.py
@@ -35,7 +35,7 @@ class Interface(Module):
     def addresses(self):
         """Return ipv4 and ipv6 addresses on the interface
 
-        >>> Interface("eth0").addresses
+        >>> host.interface("eth0").addresses
         ['192.168.31.254', '192.168.31.252', 'fe80::e291:f5ff:fe98:6b8c']
         """
         raise NotImplementedError
@@ -44,11 +44,10 @@ class Interface(Module):
         return "<interface %s>" % (self.name,)
 
     @classmethod
-    def get_module_class(cls, _backend):
-        SystemInfo = _backend.get_module("SystemInfo")
-        if SystemInfo.type == "linux":
+    def get_module_class(cls, host):
+        if host.system_info.type == "linux":
             return LinuxInterface
-        elif SystemInfo.type.endswith("bsd"):
+        elif host.system_info.type.endswith("bsd"):
             return BSDInterface
         else:
             raise NotImplementedError

--- a/testinfra/modules/mountpoint.py
+++ b/testinfra/modules/mountpoint.py
@@ -32,10 +32,10 @@ class MountPoint(Module):
     def exists(self):
         """Return True if the mountpoint exists
 
-        >>> MountPoint("/").exists
+        >>> host.mount_point("/").exists
         True
 
-        >>> MountPoint("/not/a/mountpoint").exists
+        >>> host.mount_point("/not/a/mountpoint").exists
         False
 
         """
@@ -56,7 +56,7 @@ class MountPoint(Module):
     def filesystem(self):
         """Returns the filesystem type associated
 
-        >>> MountPoint("/").filesystem
+        >>> host.mount_point("/").filesystem
         'ext4'
 
         """
@@ -66,7 +66,7 @@ class MountPoint(Module):
     def device(self):
         """Return the device associated
 
-        >>> MountPoint("/").device
+        >>> host.mount_point("/").device
         '/dev/sda1'
 
         """
@@ -76,7 +76,7 @@ class MountPoint(Module):
     def options(self):
         """Return a list of options that a mount point has been created with
 
-        >>> MountPoint("/").options
+        >>> host.mount_point("/").options
         ['rw', 'relatime', 'data=ordered']
 
         """
@@ -86,7 +86,7 @@ class MountPoint(Module):
     def get_mountpoints(cls):
         """Returns a list of MountPoint instances
 
-        >>> MountPoint.get_mountpoints()
+        >>> host.mount_point.get_mountpoints()
         [<MountPoint(path=/proc, device=proc, filesystem=proc, options=rw,nosuid,nodev,noexec,relatime)>
          <MountPoint(path=/, device=/dev/sda1, filesystem=ext4, options=rw,relatime,errors=remount-ro,data=ordered)>]
         """  # noqa
@@ -96,11 +96,10 @@ class MountPoint(Module):
         return mountpoints
 
     @classmethod
-    def get_module_class(cls, _backend):
-        SystemInfo = _backend.get_module("SystemInfo")
-        if SystemInfo.type == "linux":
+    def get_module_class(cls, host):
+        if host.system_info.type == "linux":
             return LinuxMountPoint
-        elif SystemInfo.type.endswith("bsd"):
+        elif host.system_info.type.endswith("bsd"):
             return BSDMountPoint
         else:
             raise NotImplementedError

--- a/testinfra/modules/package.py
+++ b/testinfra/modules/package.py
@@ -27,7 +27,7 @@ class Package(Module):
     def is_installed(self):
         """Test if the package is installed
 
-        >>> Package("nginx").is_installed
+        >>> host.package("nginx").is_installed
         True
 
         Supported package systems:
@@ -44,7 +44,7 @@ class Package(Module):
     def release(self):
         """Return the release specific info from the package version
 
-        >>> Package("nginx").release
+        >>> host.package("nginx").release
         '1.el6'
         """
         raise NotImplementedError
@@ -53,7 +53,7 @@ class Package(Module):
     def version(self):
         """Return package version as returned by the package system
 
-        >>> Package("nginx").version
+        >>> host.package("nginx").version
         '1.2.1-2.2+wheezy3'
         """
         raise NotImplementedError
@@ -62,16 +62,14 @@ class Package(Module):
         return "<package %s>" % (self.name,)
 
     @classmethod
-    def get_module_class(cls, _backend):
-        Command = _backend.get_module("Command")
-        SystemInfo = _backend.get_module("SystemInfo")
-        if SystemInfo.type == "freebsd":
+    def get_module_class(cls, host):
+        if host.system_info.type == "freebsd":
             return FreeBSDPackage
-        elif SystemInfo.type in ("openbsd", "netbsd"):
+        elif host.system_info.type in ("openbsd", "netbsd"):
             return OpenBSDPackage
-        elif Command.exists("dpkg-query"):
+        elif host.exists("dpkg-query"):
             return DebianPackage
-        elif Command.exists("rpm"):
+        elif host.exists("rpm"):
             return RpmPackage
         else:
             raise NotImplementedError

--- a/testinfra/modules/pip.py
+++ b/testinfra/modules/pip.py
@@ -24,7 +24,7 @@ class PipPackage(InstanceModule):
     def get_packages(self, pip_path="pip"):
         """Get all installed packages and versions returned by `pip list`:
 
-        >>> PipPackage.get_packages(pip_path='~/venv/website/bin/pip')
+        >>> host.pip_package.get_packages(pip_path='~/venv/website/bin/pip')
         {'Django': {'version': '1.10.2'},
          'mywebsite': {'version': '1.0a3', 'path': '/srv/website'},
          'psycopg2': {'version': '2.6.2'}}
@@ -51,7 +51,8 @@ class PipPackage(InstanceModule):
     def get_outdated_packages(self, pip_path="pip"):
         """Get all outdated packages with current and latest version
 
-        >>> PipPackage.get_outdated_packages(pip_path='~/venv/website/bin/pip')
+        >>> host.pip_package.get_outdated_packages(
+        ...     pip_path='~/venv/website/bin/pip')
         {'Django': {'current': '1.10.2', 'latest': '1.10.3'}}
         """
         output_re = [re.compile(r) for r in [

--- a/testinfra/modules/process.py
+++ b/testinfra/modules/process.py
@@ -55,19 +55,19 @@ class Process(InstanceModule):
     <http://man7.org/linux/man-pages/man1/ps.1.html#STANDARD_FORMAT
     SPECIFIERS>`_.
 
-    >>> master = Process.get(user="root", comm="nginx")
+    >>> master = host.process.get(user="root", comm="nginx")
     # Here is the master nginx process (running as root)
     >>> master.args
     'nginx: master process /usr/sbin/nginx -g daemon on; master_process on;'
     # Here are the worker processes (Parent PID = master PID)
-    >>> workers = Process.filter(ppid=master.pid)
+    >>> workers = host.process.filter(ppid=master.pid)
     >>> len(workers)
     4
     # Nginx don't eat memory
     >>> sum([w.pmem for w in workers])
     0.8
     # But php does !
-    >>> sum([p.pmem for p in Process.filter(comm="php5-fpm")])
+    >>> sum([p.pmem for p in host.process.filter(comm="php5-fpm")])
     19.2
 
     """
@@ -75,7 +75,7 @@ class Process(InstanceModule):
     def filter(self, **filters):
         """Get a list of matching process
 
-        >>> Process.filter(user="root", comm="zsh")
+        >>> host.process.filter(user="root", comm="zsh")
         [<process zsh (pid=2715)>, <process zsh (pid=10502)>, ...]
         """
         match = []
@@ -110,9 +110,9 @@ class Process(InstanceModule):
         raise NotImplementedError
 
     @classmethod
-    def get_module_class(cls, _backend):
-        SystemInfo = _backend.get_module("SystemInfo")
-        if SystemInfo.type == "linux" or SystemInfo.type.endswith("bsd"):
+    def get_module_class(cls, host):
+        if (host.system_info.type == "linux"
+                or host.system_info.type.endswith("bsd")):
             return PosixProcess
         else:
             raise NotImplementedError

--- a/testinfra/modules/process.py
+++ b/testinfra/modules/process.py
@@ -96,14 +96,13 @@ class Process(InstanceModule):
         matching filters.
         """
         matches = self.filter(**filters)
-        if len(matches) == 0:
+        if not matches:
             raise RuntimeError("No process found")
         elif len(matches) > 1:
             raise RuntimeError("Multiple process found: %s" % (matches,))
-        else:
-            return matches[0]
+        return matches[0]
 
-    def _get_processes(self, *values, **filters):
+    def _get_processes(self, **filters):
         raise NotImplementedError
 
     def _get_process_attribute_by_pid(self, pid, name):

--- a/testinfra/modules/puppet.py
+++ b/testinfra/modules/puppet.py
@@ -61,7 +61,7 @@ class PuppetResource(InstanceModule):
 
     Run ``puppet resource --types`` to get a list of available types.
 
-    >>> PuppetResource("user", "www-data")
+    >>> host.puppet_resource("user", "www-data")
     {
         'www-data': {
             'ensure': 'present',
@@ -90,13 +90,13 @@ class PuppetResource(InstanceModule):
 class Facter(InstanceModule):
     """Get facts with `facter <https://puppetlabs.com/facter>`_
 
-    >>> Facter()
+    >>> host.facter()
     {
         "operatingsystem": "Debian",
         "kernel": "linux",
         [...]
     }
-    >>> Facter("kernelversion", "is_virtual")
+    >>> host.facter("kernelversion", "is_virtual")
     {
       "kernelversion": "3.16.0",
       "is_virtual": "false"

--- a/testinfra/modules/salt.py
+++ b/testinfra/modules/salt.py
@@ -25,11 +25,11 @@ class Salt(InstanceModule):
     """Run salt module functions
 
 
-    >>> Salt("pkg.version", "nginx")
+    >>> host.salt("pkg.version", "nginx")
     '1.6.2-5'
-    >>> Salt("pkg.version", ["nginx", "php5-fpm"])
+    >>> host.salt("pkg.version", ["nginx", "php5-fpm"])
     {'nginx': '1.6.2-5', 'php5-fpm': '5.6.7+dfsg-1'}
-    >>> Salt("grains.item", ["osarch", "mem_total", "num_cpus"])
+    >>> host.salt("grains.item", ["osarch", "mem_total", "num_cpus"])
     {'osarch': 'amd64', 'num_cpus': 4, 'mem_total': 15520}
 
     Run ``salt-call sys.doc`` to get a complete list of functions
@@ -39,8 +39,8 @@ class Salt(InstanceModule):
         args = args or []
         if isinstance(args, six.string_types):
             args = [args]
-        if self._backend.HAS_RUN_SALT:
-            return self._backend.run_salt(function, args)
+        if self._host.backend.HAS_RUN_SALT:
+            return self._host.backend.run_salt(function, args)
         else:
             cmd = "salt-call --out=json"
             if local:

--- a/testinfra/modules/service.py
+++ b/testinfra/modules/service.py
@@ -54,16 +54,14 @@ class Service(Module):
                 return SystemdService
             elif host.exists("initctl"):
                 return UpstartService
-            else:
-                return SysvService
+            return SysvService
         elif host.system_info.type == "freebsd":
             return FreeBSDService
         elif host.system_info.type == "openbsd":
             return OpenBSDService
         elif host.system_info.type == "netbsd":
             return NetBSDService
-        else:
-            raise NotImplementedError
+        raise NotImplementedError
 
     def __repr__(self):
         return "<service %s>" % (self.name,)
@@ -103,10 +101,9 @@ class SystemdService(SysvService):
             return True
         elif cmd.stdout.strip() == "disabled":
             return False
-        else:
-            # Fallback on SysV
-            # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=760616
-            return super(SystemdService, self).is_enabled
+        # Fallback on SysV
+        # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=760616
+        return super(SystemdService, self).is_enabled
 
 
 class UpstartService(SysvService):
@@ -121,17 +118,15 @@ class UpstartService(SysvService):
             self.name,
         ).rc != 0:
             return True
-        else:
-            # Fallback on SysV
-            return super(UpstartService, self).is_enabled
+        # Fallback on SysV
+        return super(UpstartService, self).is_enabled
 
     @property
     def is_running(self):
         cmd = self.run_test('status %s', self.name)
         if cmd.rc == 0 and len(cmd.stdout.split()) > 1:
             return 'running' in cmd.stdout.split()[1]
-        else:
-            return super(UpstartService, self).is_running
+        return super(UpstartService, self).is_running
 
 
 class FreeBSDService(Service):

--- a/testinfra/modules/service.py
+++ b/testinfra/modules/service.py
@@ -45,25 +45,22 @@ class Service(Module):
         raise NotImplementedError
 
     @classmethod
-    def get_module_class(cls, _backend):
-        SystemInfo = _backend.get_module("SystemInfo")
-        File = _backend.get_module("File")
-        Command = _backend.get_module("Command")
-        if SystemInfo.type == "linux":
+    def get_module_class(cls, host):
+        if host.system_info.type == "linux":
             if (
-                Command.exists("systemctl")
-                and "systemd" in File("/sbin/init").linked_to
+                host.exists("systemctl")
+                and "systemd" in host.file("/sbin/init").linked_to
             ):
                 return SystemdService
-            elif Command.exists("initctl"):
+            elif host.exists("initctl"):
                 return UpstartService
             else:
                 return SysvService
-        elif SystemInfo.type == "freebsd":
+        elif host.system_info.type == "freebsd":
             return FreeBSDService
-        elif SystemInfo.type == "openbsd":
+        elif host.system_info.type == "openbsd":
             return OpenBSDService
-        elif SystemInfo.type == "netbsd":
+        elif host.system_info.type == "netbsd":
             return NetBSDService
         else:
             raise NotImplementedError

--- a/testinfra/modules/socket.py
+++ b/testinfra/modules/socket.py
@@ -92,14 +92,14 @@ class Socket(Module):
     def is_listening(self):
         """Test if socket is listening
 
-        >>> Socket("unix:///var/run/docker.sock").is_listening
+        >>> host.socket("unix:///var/run/docker.sock").is_listening
         False
         >>> # This HTTP server listen on all ipv4 adresses but not on ipv6
-        >>> Socket("tcp://0.0.0.0:80").is_listening
+        >>> host.socket("tcp://0.0.0.0:80").is_listening
         True
-        >>> Socket("tcp://:::80").is_listening
+        >>> host.socket("tcp://:::80").is_listening
         False
-        >>> Socket("tcp://80").is_listening
+        >>> host.socket("tcp://80").is_listening
         False
 
         .. note:: If you don't specify a host for udp and tcp sockets,
@@ -132,9 +132,9 @@ class Socket(Module):
         For unix sockets a list of None is returned (thus you can make a
         len() for counting clients).
 
-        >>> Socket("tcp://22").clients
+        >>> host.socket("tcp://22").clients
         [('2001:db8:0:1', 44298), ('192.168.31.254', 34866)]
-        >>> Socket("unix:///var/run/docker.sock")
+        >>> host.socket("unix:///var/run/docker.sock")
         [None, None, None]
 
         """
@@ -164,7 +164,7 @@ class Socket(Module):
     def get_listening_sockets(cls):
         """Return a list of all listening sockets
 
-        >>> Socket.get_listening_sockets()
+        >>> host.socket.get_listening_sockets()
         ['tcp://0.0.0.0:22', 'tcp://:::22', 'unix:///run/systemd/private', ...]
         """
         sockets = []
@@ -188,11 +188,10 @@ class Socket(Module):
         )
 
     @classmethod
-    def get_module_class(cls, _backend):
-        SystemInfo = _backend.get_module("SystemInfo")
-        if SystemInfo.type == "linux":
+    def get_module_class(cls, host):
+        if host.system_info.type == "linux":
             return LinuxSocket
-        elif SystemInfo.type.endswith("bsd"):
+        elif host.system_info.type.endswith("bsd"):
             return BSDSocket
         else:
             raise NotImplementedError

--- a/testinfra/modules/socket.py
+++ b/testinfra/modules/socket.py
@@ -110,19 +110,18 @@ class Socket(Module):
         sockets = self.get_sockets(True)
         if self.protocol == "unix":
             return ("unix", self.host) in sockets
-        else:
-            allipv4 = (self.protocol, "0.0.0.0", self.port) in sockets
-            allipv6 = (self.protocol, "::", self.port) in sockets
-            return (
-                all([allipv4, allipv6])
-                or (
-                    self.host is not None
-                    and (
-                        (":" in self.host and allipv6 in sockets)
-                        or (":" not in self.host and allipv4 in sockets)
-                        or (self.protocol, self.host, self.port) in sockets)
-                    )
-            )
+        allipv4 = (self.protocol, "0.0.0.0", self.port) in sockets
+        allipv6 = (self.protocol, "::", self.port) in sockets
+        return (
+            all([allipv4, allipv6])
+            or (
+                self.host is not None
+                and (
+                    (":" in self.host and allipv6 in sockets)
+                    or (":" not in self.host and allipv4 in sockets)
+                    or (self.protocol, self.host, self.port) in sockets)
+                )
+        )
 
     @property
     def clients(self):

--- a/testinfra/modules/sudo.py
+++ b/testinfra/modules/sudo.py
@@ -26,10 +26,10 @@ class Sudo(InstanceModule):
 
     >>> Command.check_output("whoami")
     'phil'
-    >>> with Sudo():
-    ...     Command.check_output("whoami")
-    ...     with Sudo("www-data"):
-    ...         Command.check_output("whoami")
+    >>> with host.sudo():
+    ...     host.check_output("whoami")
+    ...     with host.sudo("www-data"):
+    ...         host.check_output("whoami")
     ...
     'root'
     'www-data'
@@ -37,19 +37,19 @@ class Sudo(InstanceModule):
     """
     @contextlib.contextmanager
     def __call__(self, user=None):
-        old_get_command = self._backend.get_command
-        quote = self._backend.quote
-        get_sudo_command = self._backend.get_sudo_command
+        old_get_command = self._host.backend.get_command
+        quote = self._host.backend.quote
+        get_sudo_command = self._host.backend.get_sudo_command
 
         def get_command(command, *args):
             return old_get_command(
                 get_sudo_command(quote(command, *args), user))
 
-        self._backend.get_command = get_command
+        self._host.backend.get_command = get_command
         try:
             yield
         finally:
-            self._backend.get_command = old_get_command
+            self._host.backend.get_command = old_get_command
 
     def __repr__(self):
         return "<sudo>"

--- a/testinfra/modules/supervisor.py
+++ b/testinfra/modules/supervisor.py
@@ -23,7 +23,7 @@ STATUS = [
 class Supervisor(Module):
     """Test supervisor managed services
 
-    >>> gunicorn = Supervisor("gunicorn")
+    >>> gunicorn = host.supervisor("gunicorn")
     >>> gunicorn.status
     'RUNNING'
     >>> gunicorn.is_running
@@ -92,7 +92,7 @@ class Supervisor(Module):
     def get_services(cls):
         """Get a list of services running under supervisor
 
-        >>> Supervisor.get_services()
+        >>> host.supervisor.get_services()
         [<Supervisor(name="gunicorn", status="RUNNING", pid=4232)>
          <Supervisor(name="celery", status="FATAL", pid=None)>]
         """

--- a/testinfra/modules/sysctl.py
+++ b/testinfra/modules/sysctl.py
@@ -19,9 +19,9 @@ from testinfra.modules.base import InstanceModule
 class Sysctl(InstanceModule):
     """Test kernel parameters
 
-    >>> Sysctl("kernel.osrelease")
+    >>> host.sysctl("kernel.osrelease")
     "3.16.0-4-amd64"
-    >>> Sysctl("vm.dirty_ratio")
+    >>> host.sysctl("vm.dirty_ratio")
     20
     """
 

--- a/testinfra/modules/systeminfo.py
+++ b/testinfra/modules/systeminfo.py
@@ -116,7 +116,7 @@ class SystemInfo(InstanceModule):
     def type(self):
         """OS type
 
-        >>> SystemInfo.type
+        >>> host.system_info.type
         'linux'
         """
         return self.sysinfo["type"]
@@ -125,7 +125,7 @@ class SystemInfo(InstanceModule):
     def distribution(self):
         """Distribution name
 
-        >>> SystemInfo.distribution
+        >>> host.system_info.distribution
         'debian'
         """
         return self.sysinfo["distribution"]
@@ -134,7 +134,7 @@ class SystemInfo(InstanceModule):
     def release(self):
         """Distribution release number
 
-        >>> SystemInfo.release
+        >>> host.system_info.release
         '7.8'
         """
         return self.sysinfo["release"]
@@ -143,7 +143,7 @@ class SystemInfo(InstanceModule):
     def codename(self):
         """Release code name
 
-        >>> SystemInfo.codename
+        >>> host.system_info.codename
         'wheezy'
         """
         return self.sysinfo["codename"]

--- a/testinfra/modules/user.py
+++ b/testinfra/modules/user.py
@@ -90,9 +90,9 @@ class User(Module):
     def expiration_date(self):
         """Return the account expiration date
 
-        >>> User("phil").expiration_date
+        >>> host.user("phil").expiration_date
         datetime.datetime(2020, 1, 1, 0, 0)
-        >>> User("root").expiration_date
+        >>> host.user("root").expiration_date
         None
         """
         days = self.check_output("getent shadow %s", self.name).split(":")[7]
@@ -106,11 +106,10 @@ class User(Module):
             return epoch + datetime.timedelta(days=int(days))
 
     @classmethod
-    def get_module_class(cls, _backend):
-        SystemInfo = _backend.get_module("SystemInfo")
-        if SystemInfo.type.endswith("bsd"):
+    def get_module_class(cls, host):
+        if host.system_info.type.endswith("bsd"):
             return BSDUser
-        return super(User, cls).get_module_class(_backend)
+        return super(User, cls).get_module_class(host)
 
     def __repr__(self):
         return "<user %s>" % (self.name,)

--- a/testinfra/test/conftest.py
+++ b/testinfra/test/conftest.py
@@ -145,7 +145,7 @@ initialize_container_fixtures()
 
 
 @pytest.fixture
-def TestinfraBackend(request, tmpdir_factory):
+def host(request, tmpdir_factory):
     if not has_docker():
         pytest.skip()
         return
@@ -208,18 +208,18 @@ def TestinfraBackend(request, tmpdir_factory):
     else:
         hostspec = host
 
-    backend = testinfra.get_backend(hostspec, **kw)
-    backend.get_hostname = lambda: image
-    return backend
+    host = testinfra.host.get_host(hostspec, **kw)
+    host.backend.get_hostname = lambda: image
+    return host
 
 
 @pytest.fixture
-def docker_image(TestinfraBackend):
-    return TestinfraBackend.get_hostname()
+def docker_image(host):
+    return host.backend.get_hostname()
 
 
 def pytest_generate_tests(metafunc):
-    if "TestinfraBackend" in metafunc.fixturenames:
+    if "host" in metafunc.fixturenames:
         marker = getattr(metafunc.function, "testinfra_hosts", None)
         if marker is not None:
             hosts = marker.args
@@ -227,7 +227,7 @@ def pytest_generate_tests(metafunc):
             # Default
             hosts = ["docker://debian_jessie"]
 
-        metafunc.parametrize("TestinfraBackend", hosts, indirect=True,
+        metafunc.parametrize("host", hosts, indirect=True,
                              scope="function")
 
 

--- a/testinfra/utils/__init__.py
+++ b/testinfra/utils/__init__.py
@@ -1,0 +1,24 @@
+# coding: utf-8
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import unicode_literals
+
+import re
+
+first_cap_re = re.compile('(.)([A-Z][a-z]+)')
+all_cap_re = re.compile('([a-z0-9])([A-Z])')
+
+
+def un_camel_case(name):
+    s1 = first_cap_re.sub(r'\1_\2', name)
+    return all_cap_re.sub(r'\1_\2', s1).lower()

--- a/testinfra/utils/ansible_runner.py
+++ b/testinfra/utils/ansible_runner.py
@@ -59,7 +59,7 @@ class AnsibleRunnerBase(object):
     def get_variables(self, host):
         raise NotImplementedError
 
-    def run(self, module_name, module_args, **kwargs):
+    def run(self, host, module_name, module_args, **kwargs):
         raise NotImplementedError
 
 


### PR DESCRIPTION
Related to #151

I opted to name the fixture ``host`` and use un-camel-case module name (eg. SystemInfo -> system_info).

Currently the fixture should work and old test suite should pass

TODO:

- [x] Find a proper way to share cache betwen host and backend.
- [x] Deprecate old fixtures
- [x] Migrate tests to use new fixture
- [x] Document the new fixtures
- [x] make shortcut (eg ``host.check_output(cmd)`` instead of ``host.command.check_output(cmd)``