### PR TITLE
Add sysinfo for macOS

### DIFF
--- a/testinfra/modules/systeminfo.py
+++ b/testinfra/modules/systeminfo.py
@@ -77,6 +77,22 @@ class SystemInfo(InstanceModule):
 
         return sysinfo
 
+    def _get_darwin_sysinfo(self):
+        sysinfo = {}
+
+        sw_vers = self.run("sw_vers")
+        if sw_vers.rc == 0:
+            for line in sw_vers.stdout.splitlines():
+                key, value = line.split(":", 1)
+                key = key.strip().lower()
+                value = value.strip()
+                if key == "productname":
+                    sysinfo["distribution"] = value
+                elif key == "productversion":
+                    sysinfo["release"] = value
+
+        return sysinfo
+
     def get_system_info(self):
         sysinfo = {
             "type": None,
@@ -87,6 +103,8 @@ class SystemInfo(InstanceModule):
         sysinfo["type"] = self.check_output("uname -s").lower()
         if sysinfo["type"] == "linux":
             sysinfo.update(**self._get_linux_sysinfo())
+        elif sysinfo["type"] == "darwin":
+            sysinfo.update(**self._get_darwin_sysinfo())
         else:
             # BSD
             sysinfo["release"] = self.check_output("uname -r")


### PR DESCRIPTION
When the uname comes back as "darwin", add info about distribution and
version, as provided by the "sw_ver" utility.

At the moment it's not possible without ugly hacks to provide the code
names (Tiger, Lion, Mavericks, etc).
See
http://unix.stackexchange.com/questions/234104/get-osx-codename-from-command-line