### PR TITLE
Restore backend command if sudo fails

### DIFF
--- a/images/debian_jessie/Dockerfile
+++ b/images/debian_jessie/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update && \
     useradd -m user -c "gecos.comment" && \
     adduser user sudo && \
     echo "user ALL=NOPASSWD: ALL" > /etc/sudoers.d/user && \
+    useradd -m unprivileged && \
     mkdir -p /root/.ssh && \
     echo "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCgDryK4AjJeifuc2N54St13KMNlnGLAtibQSMmvSyrhH7XJ1atnBo1HrJhGZNNBVKM67+zYNc9J3fg3qI1g63vSQAA+nXMsDYwu4BPwupakpwJELcGZJxsUGzjGVotVpqPIX5nW8NBGvkVuObI4UELOleq5mQMTGerJO64KkSVi20FDwPJn3q8GG2zk3pESiDA5ShEyFhYC8vOLfSSYD0LYmShAVGCLEgiNb+OXQL6ZRvzqfFEzL0QvaI/l3mb6b0VFPAO4QWOL0xj3cWzOZXOqht3V85CZvSk8ISdNgwCjXLZsPeaYL/toHNvBF30VMrDZ7w4SDU0ZZLEsc/ezxjb" > /root/.ssh/authorized_keys && \
     mkdir -p /home/user/.ssh && \

--- a/testinfra/modules/sudo.py
+++ b/testinfra/modules/sudo.py
@@ -46,8 +46,10 @@ class Sudo(InstanceModule):
                 get_sudo_command(quote(command, *args), user))
 
         self._backend.get_command = get_command
-        yield
-        self._backend.get_command = old_get_command
+        try:
+            yield
+        finally:
+            self._backend.get_command = old_get_command
 
     def __repr__(self):
         return "<sudo>"

--- a/testinfra/test/test_modules.py
+++ b/testinfra/test/test_modules.py
@@ -402,6 +402,17 @@ def test_sudo_from_root(Sudo, User):
     assert User().name == "root"
 
 
+def test_sudo_fail_from_root(Command, Sudo, User):
+    assert User().name == "root"
+    with pytest.raises(Exception) as exc:
+        with Sudo("unprivileged"):
+            assert User().name == "unprivileged"
+            Command.check_output('ls /root/invalid')
+    assert exc.value.msg.startswith('Unexpected exit code')
+    with Sudo():
+        assert User().name == "root"
+
+
 @pytest.mark.testinfra_hosts("docker://user@debian_jessie")
 def test_sudo_to_root(Sudo, User):
     assert User().name == "user"


### PR DESCRIPTION
If a Sudo Command fails the backend command isn't restored by the context manager. If you then run another Command in a different test method the Sudo context is still active, which may lead to it failing if that user was unprivileged.

This PR adds a test demonstrating the problem, and a fix.

Travis is failing, but I think that's for reasons unrelated to this PR- it's also [failing on the master branch](https://travis-ci.org/manics/testinfra/builds/195503413).