### PR TITLE
Added Molecule to docs

### DIFF
--- a/doc/source/support.rst
+++ b/doc/source/support.rst
@@ -19,3 +19,8 @@ pytest documentation
 
 testinfra is implemented as pytest plugin so to get the most out of please
 read `pytest documentation <http://pytest.org>`_
+
+Community Contributions
+~~~~~~~~~~~~~~~~~~~~~~~
+
+* `Molecule <http://molecule.readthedocs.io>`_ is an Automated testing framework for Ansible roles, with native Testinfra support.


### PR DESCRIPTION
Added Molecule[1] to the 'Community Contributions' section of
the docs. Testinfra is a native and *default* Molecule verifier[2].

[1] http://molecule.readthedocs.io
[2] http://molecule.readthedocs.io/en/stable-1.20/verifier.html#testinfra