### PR TITLE
Service: fix Upstart is_running test

### DIFF
--- a/testinfra/modules/service.py
+++ b/testinfra/modules/service.py
@@ -128,6 +128,14 @@ class UpstartService(SysvService):
             # Fallback on SysV
             return super(UpstartService, self).is_enabled
 
+    @property
+    def is_running(self):
+        cmd = self.run_test('status %s', self.name)
+        if cmd.rc == 0 and len(cmd.stdout.split()) > 1:
+            return 'running' in cmd.stdout.split()[1]
+        else:
+            return super(UpstartService, self).is_running
+
 
 class FreeBSDService(Service):
 


### PR DESCRIPTION
When a service is managed by Upstart, the "service my-service status"
command returns exit code 0 even when the service is stopped, which
means UpstartService.is_running was true even when the service wasn't
running.

So instead of relying on the exit code, match the "running" string in
the output of "status my-service".