### PR TITLE
backend: fallback to UTF-8 encoding

### DIFF
--- a/testinfra/backend/base.py
+++ b/testinfra/backend/base.py
@@ -203,6 +203,9 @@ class BaseBackend(object):
             # Python is not installed, we hope the encoding to be the same as
             # local machine...
             encoding = locale.getpreferredencoding()
+        if encoding == "ANSI_X3.4-1968":
+            # Workaround defaut encoding ascii without LANG set
+            encoding = "UTF-8"
         return encoding
 
     @property

--- a/testinfra/test/test_backends.py
+++ b/testinfra/test/test_backends.py
@@ -90,3 +90,13 @@ def test_backend_importables():
             pytest.skip()
         obj = testinfra.backend.get_backend_class(connection_type)
         assert obj.get_connection_type() == connection_type
+
+
+@pytest.mark.testinfra_hosts("docker://centos_7", "ssh://centos_7")
+def test_docker_encoding(Command, File):
+    encoding = Command.check_output(
+        "python -c 'import locale;print(locale.getpreferredencoding())'")
+    assert encoding == "ANSI_X3.4-1968"
+    string = "ťēꞩƫìṇḟřặ ṧꝕèȃǩ ửƫᵮ8"
+    assert Command.check_output("echo %s | tee /tmp/s.txt", string) == string
+    assert File("/tmp/s.txt").content_string.strip() == string


### PR DESCRIPTION
By default most docker images doesn't have LANG set and
locale.getpreferredencoding() default to "ANSI_X3.4-1968" (ascii) and
generate encoding/decoding errors.
As a workaround, fallback to UTF-8 encoding.

Closes #140