### PR TITLE
ansible: fix ansible.cli usage

### DIFF
--- a/testinfra/test/test_modules.py
+++ b/testinfra/test/test_modules.py
@@ -312,7 +312,7 @@ def test_ansible_module(TestinfraBackend, Ansible):
     with pytest.raises(Ansible.AnsibleException) as excinfo:
         Ansible("file", "path=/etc/passwd an_unexpected=variable")
     tb = str(excinfo.value)
-    assert 'unsupported parameter for module: an_unexpected' in tb
+    assert 'unsupported parameter' in tb.lower()
 
     with pytest.raises(Ansible.AnsibleException) as excinfo:
         Ansible("command", "zzz")

--- a/testinfra/utils/ansible_runner.py
+++ b/testinfra/utils/ansible_runner.py
@@ -31,7 +31,7 @@ if _ansible_major_version == 1:
     import ansible.runner
     import ansible.utils
 elif _ansible_major_version == 2:
-    import ansible.cli
+    import ansible.cli.playbook
     import ansible.executor.task_queue_manager
     import ansible.inventory
     import ansible.parsing.dataloader
@@ -138,8 +138,8 @@ class AnsibleRunnerV2(AnsibleRunnerBase):
         super(AnsibleRunnerV2, self).__init__(host_list)
         _reload_constants()
         self.variable_manager = ansible.vars.VariableManager()
-        self.cli = ansible.cli.CLI(None)
-        self.cli.options = ansible.cli.CLI(None).base_parser(
+        self.cli = ansible.cli.playbook.PlaybookCLI(None)
+        self.cli.options = self.cli.base_parser(
             connect_opts=True,
             meta_opts=True,
             runas_opts=True,
@@ -155,7 +155,7 @@ class AnsibleRunnerV2(AnsibleRunnerBase):
         self.cli.options.connection = "smart"
         self.loader = ansible.parsing.dataloader.DataLoader()
         if self.cli.options.vault_password_file:
-            vault_pass = ansible.cli.CLI.read_vault_password_file(
+            vault_pass = self.cli.read_vault_password_file(
                 self.cli.options.vault_password_file, loader=self.loader)
             self.loader.set_vault_password(vault_pass)
 


### PR DESCRIPTION
ansible.cli.CLI is now an abstract class, use concrete class
ansible.cli.playbook.PlaybookCLI instead.

Also avoid instanciate multiple CLI, and reuse self.cli to call methods.

This fix usage with ansible >= 2.3 where abstract class ansible.cli.CLI
cannot be instanciated directly.

Closes #194