### PR TITLE
backend: support py3 with ansible 2.3

### DIFF
--- a/test/test_backends.py
+++ b/test/test_backends.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 from __future__ import unicode_literals
 import pytest
-import six
 
 import testinfra.backend
 BACKENDS = ("ssh", "safe-ssh", "docker", "paramiko", "ansible")
@@ -86,8 +85,6 @@ def test_backend_importables():
     # just check that all declared backend are importable and NAME is set
     # correctly
     for connection_type in testinfra.backend.BACKENDS:
-        if six.PY3 and connection_type == 'ansible':
-            pytest.skip()
         obj = testinfra.backend.get_backend_class(connection_type)
         assert obj.get_connection_type() == connection_type
 

--- a/testinfra/utils/ansible_runner.py
+++ b/testinfra/utils/ansible_runner.py
@@ -16,7 +16,9 @@
 from __future__ import unicode_literals
 from __future__ import absolute_import
 
+import imp
 import pprint
+
 
 try:
     import ansible
@@ -40,11 +42,19 @@ elif _ansible_major_version == 2:
     import ansible.utils.vars
     import ansible.vars
 
+try:
+    from ansible.module_utils._text import to_bytes
+except ImportError:
+    from ansible.utils.unicode import to_bytes
+
+
+__all__ = ['AnsibleRunner', 'to_bytes']
+
 
 def _reload_constants():
     # Reload defaults that can depend on environment variables and
     # current working directory
-    reload(ansible.constants)
+    imp.reload(ansible.constants)
 
 
 class AnsibleRunnerBase(object):

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist=py27,ansible1,py34,flake8,pylint,sphinxdoc
 [testenv]
 deps=
     -rtest-requirements.txt
-    py27: ansible>=2.3,<3
+    ansible>=2.3,<3
 commands=
     testinfra {posargs:-v -n 4 --cov testinfra --cov-report xml --cov-report term test}
 usedevelop=True


### PR DESCRIPTION
Use imp.reload instead of reload
Don't attempt to encode stdout/stderr, do it in a lazy way and using
ansible 'to_bytes' which handle surrogateescape.

Closes #197