### PR TITLE
host: fix use of deprecated api

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -157,7 +157,7 @@ def host(request, tmpdir_factory):
         scope = "session"
 
     fname = "_docker_container_%s_%s" % (host, scope)
-    docker_id, docker_host, port = request.getfuncargvalue(fname)
+    docker_id, docker_host, port = request.getfixturevalue(fname)
 
     if kw["connection"] == "docker":
         host = docker_id

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -105,11 +105,6 @@ def test_ssh_service(host, docker_image):
     ("salt-minion", False, False),
 ])
 def test_service(host, name, running, enabled):
-
-    if name == "ntp":
-        # Systemd say no but sysv say yes
-        assert host.run("systemctl is-enabled ntp").rc == 1
-
     service = host.service(name)
     assert service.is_running == running
     assert service.is_enabled == enabled

--- a/testinfra/host.py
+++ b/testinfra/host.py
@@ -88,7 +88,7 @@ class Host(object):
     def __getattr__(self, name):
         assert name in testinfra.modules.modules, name + " is not a module"
         module_class = testinfra.modules.get_module_class(name)
-        obj = module_class.get_module(self.backend)
+        obj = module_class.get_module(self)
         setattr(self, name, obj)
         return obj
 


### PR DESCRIPTION
Module.get_module expect a Host, not a Backend.

Closes #204