### PR TITLE
Add ssh identity override

### DIFF
--- a/doc/source/examples.rst
+++ b/doc/source/examples.rst
@@ -140,6 +140,17 @@ You can run these tests from the nagios master or in the target host with
 `NRPE <https://en.wikipedia.org/wiki/Nagios#Nagios_Remote_Plugin_Executor>`_.
 
 
+Integration with KitchenCI
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+KitchenCI (aka Test Kitchen) can use testinfra via its :code:`shell` verifier.
+Add the following verifier to your :code:`.kitchen.yml`::
+
+    verifier:
+      name: shell
+      command: testinfra --host="paramiko://${KITCHEN_USERNAME}@${KITCHEN_HOSTNAME}:${KITCHEN_PORT}?ssh_identity_file=${KITCHEN_SSH_KEY}" --junit-xml "junit-${KITCHEN_INSTANCE}.xml" "test/integration/${KITCHEN_SUITE}"
+
+
 .. _test docker images:
 
 Test docker images

--- a/testinfra/backend/__init__.py
+++ b/testinfra/backend/__init__.py
@@ -49,7 +49,7 @@ def parse_hostspec(hostspec):
             kw["sudo"] = True
         for key in (
             "ssh_config", "ansible_inventory",
-            "sudo_user",
+            "sudo_user", "ssh_identity_file",
         ):
             if key in query:
                 kw[key] = query.get(key)[0]

--- a/testinfra/backend/paramiko.py
+++ b/testinfra/backend/paramiko.py
@@ -37,9 +37,12 @@ class IgnorePolicy(paramiko.MissingHostKeyPolicy):
 class ParamikoBackend(base.BaseBackend):
     NAME = "paramiko"
 
-    def __init__(self, hostspec, ssh_config=None, *args, **kwargs):
+    def __init__(
+            self, hostspec, ssh_config=None, ssh_identity_file=None,
+            *args, **kwargs):
         self.host, self.user, self.port = self.parse_hostspec(hostspec)
         self.ssh_config = ssh_config
+        self.ssh_identity_file = ssh_identity_file
         self._client = None
         super(ParamikoBackend, self).__init__(self.host, *args, **kwargs)
 
@@ -69,7 +72,8 @@ class ParamikoBackend(base.BaseBackend):
                         cfg["key_filename"] = os.path.expanduser(value[0])
                     elif key == "stricthostkeychecking" and value == "no":
                         client.set_missing_host_key_policy(IgnorePolicy())
-
+            if self.ssh_identity_file:
+                cfg["key_filename"] = self.ssh_identity_file
             client.connect(**cfg)
             self._client = client
         return self._client


### PR DESCRIPTION
Following [Rashit’s guide](https://medium.com/@syndicut/testing-salt-formulas-with-test-kitchen-and-testinfra-d2b8642e6a39#.suhe583j4) I got KitchenCI integrated with testinfra but only after some adaptions to both his and testinfra’s code. 

This MR introduces a parameter `ssh_identity_file` for the Paramiko backend and adds documentation on how to integrate testinfra into KitchenCI. It passed my local Tox and flake8 test although I had to change `py34` to `py35` in the `tox.ini`.