### PR TITLE
allow specifying a config dir for salt module

### DIFF
--- a/testinfra/modules/salt.py
+++ b/testinfra/modules/salt.py
@@ -42,13 +42,15 @@ class Salt(InstanceModule):
         if self._host.backend.HAS_RUN_SALT:
             return self._host.backend.run_salt(function, args)
         else:
+            cmd_args = []
             cmd = "salt-call --out=json"
             if local:
                 cmd += " --local"
             if config is not None:
-                cmd += " -c {0}".format(config)
+                cmd += " -c %s"
+                cmd_args.append(config)
             cmd += " %s" + len(args) * " %s"
-            cmd_args = [function] + args
+            cmd_args += [function] + args
             return json.loads(self.check_output(cmd, *cmd_args))["local"]
 
     def __repr__(self):

--- a/testinfra/modules/salt.py
+++ b/testinfra/modules/salt.py
@@ -35,7 +35,7 @@ class Salt(InstanceModule):
     Run ``salt-call sys.doc`` to get a complete list of functions
     """
 
-    def __call__(self, function, args=None, local=False):
+    def __call__(self, function, args=None, local=False, config=None):
         args = args or []
         if isinstance(args, six.string_types):
             args = [args]
@@ -45,6 +45,8 @@ class Salt(InstanceModule):
             cmd = "salt-call --out=json"
             if local:
                 cmd += " --local"
+            if config is not None:
+                cmd += " -c {0}".format(config)
             cmd += " %s" + len(args) * " %s"
             cmd_args = [function] + args
             return json.loads(self.check_output(cmd, *cmd_args))["local"]


### PR DESCRIPTION
This is specifically useful in kitchen-salt for me, since we are putting the configs in /tmp/kitchen/etc/salt

Thanks,
Daniel