### PR TITLE
socket: handle AF_INET6 as AF_INET4

### DIFF
--- a/testinfra/modules/socket.py
+++ b/testinfra/modules/socket.py
@@ -113,7 +113,7 @@ class Socket(Module):
         allipv4 = (self.protocol, "0.0.0.0", self.port) in sockets
         allipv6 = (self.protocol, "::", self.port) in sockets
         return (
-            all([allipv4, allipv6])
+            any([allipv6, all([allipv4, allipv6])])
             or (
                 self.host is not None
                 and (


### PR DESCRIPTION
IPv6 listening socket are actually IPv4 compatible socket.

Closes #234