### PR TITLE
Use a modified pipes.quote for winrm backend

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -7,6 +7,7 @@ disable=
     bad-continuation,
     fixme,
     locally-disabled,
+    wrong-import-order
 max-branches=13
 max-bool-expr=6
 max-args=8

--- a/test/test_backends.py
+++ b/test/test_backends.py
@@ -16,6 +16,7 @@ import pytest
 import testinfra.backend
 from testinfra.backend.base import BaseBackend
 from testinfra.backend.base import HostSpec
+from testinfra.backend.winrm import _quote
 BACKENDS = ("ssh", "safe-ssh", "docker", "paramiko", "ansible")
 HOSTS = [backend + "://debian_jessie" for backend in BACKENDS]
 USER_HOSTS = [backend + "://user@debian_jessie" for backend in BACKENDS]
@@ -110,3 +111,17 @@ def test_docker_encoding(host):
 ])
 def test_parse_hostspec(hostspec, expected):
     assert BaseBackend.parse_hostspec(hostspec) == expected
+
+
+@pytest.mark.parametrize('arg_string,expected', [
+    (
+        'C:\\Users\\vagrant\\This Dir\\salt',
+        '"C:\\Users\\vagrant\\This Dir\\salt"'
+    ),
+    (
+        'C:\\Users\\vagrant\\AppData\\Local\\Temp\\kitchen\\etc\\salt',
+        '"C:\\Users\\vagrant\\AppData\\Local\\Temp\\kitchen\\etc\\salt"'
+    ),
+])
+def test_winrm_quote(arg_string, expected):
+    assert _quote(arg_string) == expected


### PR DESCRIPTION
The winrm backend fails if the strings in it are quoted with single
quotes instead of double quotes.

@philpep I ran into problems using this on linux, probably because of the way that linux shells handle single quotes vs double quotes.

But if this gets in, it should be good for a release.

Thanks!
Daniel