### PR TITLE
Service: fix Upstart detection

### DIFF
--- a/testinfra/modules/service.py
+++ b/testinfra/modules/service.py
@@ -52,7 +52,9 @@ class Service(Module):
                 and "systemd" in host.file("/sbin/init").linked_to
             ):
                 return SystemdService
-            elif host.exists("initctl"):
+            elif (host.exists("initctl")
+                    and host.exists('status')
+                    and host.file('/etc/init').is_directory):
                 return UpstartService
             return SysvService
         elif host.system_info.type == "freebsd":


### PR DESCRIPTION
initctl can exist on non upstart system (seems that git package on
centos install a 'initctl' command).

Also check for 'status' command and presence of /etc/init directory to
detect system managed by Upstart.

Closes #243