### PR TITLE
Fix --nagios option with py.test and deprecate testinfra command

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+1.8.0
+=====
+
+* Deprecate testinfra command (will be dropped in 2.0), use py.test instead #135
+* Handle --nagios option when using py.test command
+
 1.7.1
 =====
 

--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ Write your first tests file to `test_myinfra.py`:
 
 And run it::
 
-    $ testinfra -v test_myinfra.py
+    $ py.test -v test_myinfra.py
 
 
     ====================== test session starts ======================

--- a/doc/source/backends.rst
+++ b/doc/source/backends.rst
@@ -14,7 +14,7 @@ This is the default backend when not hosts are provided (either via
 ``--hosts`` or in modules). Commands are run locally in a subprocess under
 the current user::
 
-    $ testinfra --sudo test_myinfra.py
+    $ py.test --sudo test_myinfra.py
 
 
 paramiko
@@ -28,7 +28,7 @@ able to connect without password (using password less keys or using
 
 You can provide an alternate ssh-config and use sudo on the remote host::
 
-    $ testinfra --ssh-config=/path/to/ssh_config --sudo --hosts=server
+    $ py.test --ssh-config=/path/to/ssh_config --sudo --hosts=server
 
 
 docker
@@ -37,7 +37,7 @@ docker
 The docker backend can be used to test *running* containers. It use the `docker
 exec <https://docs.docker.com/reference/commandline/exec/>`_ command::
 
-    $ testinfra --connection=docker --hosts=[user@]docker_id_or_name
+    $ py.test --connection=docker --hosts=[user@]docker_id_or_name
 
 See also the :ref:`Test docker images` example.
 
@@ -47,7 +47,7 @@ ssh
 
 This is a pure ssh backend using the ``ssh`` command available in ``$PATH``. Example::
 
-    $ testinfra --connection=ssh --hosts=server
+    $ py.test --connection=ssh --hosts=server
 
 The ssh backend also accept ``--ssh-config`` and ``--sudo`` parameters.
 
@@ -58,10 +58,10 @@ salt
 The salt backend use the `salt python client API
 <http://docs.saltstack.com/en/latest/ref/clients/>`_ and can be used from the salt-master server::
 
-    $ testinfra --connection=salt # equivalent to --hosts='*'
-    $ testinfra --connection=salt --hosts=minion1,minion2
-    $ testinfra --connection=salt --hosts='web*'
-    $ testinfra --connection=salt --hosts=G@os:Debian
+    $ py.test --connection=salt # equivalent to --hosts='*'
+    $ py.test --connection=salt --hosts=minion1,minion2
+    $ py.test --connection=salt --hosts='web*'
+    $ py.test --connection=salt --hosts=G@os:Debian
 
 Testinfra will use the salt connection channel to run commands.
 
@@ -78,9 +78,9 @@ ansible
 The ansible backend use the `ansible python API
 <https://docs.ansible.com/ansible/developing_api.html>`_::
 
-    $ testinfra --connection=ansible # tests all inventory hosts
-    $ testinfra --connection=ansible --hosts=host1,host2
-    $ testinfra --connection=ansible --hosts='web*'
+    $ py.test --connection=ansible # tests all inventory hosts
+    $ py.test --connection=ansible --hosts=host1,host2
+    $ py.test --connection=ansible --hosts='web*'
 
 You can use an alternative `inventory` with the ``--ansible-inventory`` option.
 
@@ -94,7 +94,7 @@ kubectl
 The kubectl backend can be used to test containers running in Kubernetes.
 It use the `kubectl exec <http://kubernetes.io/docs/user-guide/kubectl/kubectl_exec/>`_ command::
 
-    $ testinfra --connection=kubectl --hosts=pod_id-123456789-9fng/container_name
+    $ py.test --connection=kubectl --hosts=pod_id-123456789-9fng/container_name
 
 
 winrm
@@ -102,5 +102,5 @@ winrm
 
 The winrm backend uses `pywinrm <https://pypi.python.org/pypi/pywinrm>`_::
 
-    $ testinfra --hosts='winrm://Administrator:Password@127.0.0.1'
-    $ testinfra --connection=winrm --hosts='vagrant@127.0.0.1:2200?no_ssl=true&no_verify_ssl=true'
+    $ py.test --hosts='winrm://Administrator:Password@127.0.0.1'
+    $ py.test --connection=winrm --hosts='vagrant@127.0.0.1:2200?no_ssl=true&no_verify_ssl=true'

--- a/doc/source/examples.rst
+++ b/doc/source/examples.rst
@@ -18,7 +18,7 @@ Pytest support `test parametrization <https://pytest.org/latest/parametrize.html
 
 
     # GOOD: Each package is tested
-    # $ testinfra -v test.py
+    # $ py.test -v test.py
     # [...]
     # test.py::test_package[local-nginx-1.6] PASSED
     # test.py::test_package[local-python-2.7] PASSED
@@ -101,7 +101,7 @@ If your jenkins slave can run vagrant, your build scripts can be like::
     pip install testinfra paramiko
     vagrant up
     vagrant ssh-config > .vagrant/ssh-config
-    testinfra --hosts=default --ssh-config=.vagrant/ssh-config --junit-xml junit.xml tests.py
+    py.test --hosts=default --ssh-config=.vagrant/ssh-config --junit-xml junit.xml tests.py
 
 
 Then configure jenkins to get tests results from the `junit.xml` file.
@@ -125,12 +125,12 @@ monitoring checks, so let's push them to `Nagios <https://www.nagios.org/>`_ !
 Testinfra has an option `--nagios` that enable a compatible nagios plugin
 beharvior::
 
-    $ testinfra -qq --nagios test_ok.py; echo $?
+    $ py.test -qq --nagios test_ok.py; echo $?
     TESTINFRA OK - 2 passed, 0 failed, 0 skipped in 2.30 seconds
     [...]
     0
 
-    $ testinfra -qq --nagios test_fail.py; echo $?
+    $ py.test -qq --nagios test_fail.py; echo $?
     TESTINFRA CRITICAL - 1 passed, 1 failed, 0 skipped in 2.24 seconds
     [Traceback that explain the failed test]
     2
@@ -148,7 +148,7 @@ Add the following verifier to your :code:`.kitchen.yml`::
 
     verifier:
       name: shell
-      command: testinfra --host="paramiko://${KITCHEN_USERNAME}@${KITCHEN_HOSTNAME}:${KITCHEN_PORT}?ssh_identity_file=${KITCHEN_SSH_KEY}" --junit-xml "junit-${KITCHEN_INSTANCE}.xml" "test/integration/${KITCHEN_SUITE}"
+      command: py.test --host="paramiko://${KITCHEN_USERNAME}@${KITCHEN_HOSTNAME}:${KITCHEN_PORT}?ssh_identity_file=${KITCHEN_SSH_KEY}" --junit-xml "junit-${KITCHEN_INSTANCE}.xml" "test/integration/${KITCHEN_SUITE}"
 
 
 .. _test docker images:
@@ -257,7 +257,7 @@ Then create a `test_docker.py` file with our testinfra tests:
 
 Now let's run it::
 
-    $ testinfra -v
+    $ py.test -v
     [...]
 
     test_docker.py::test_default[debian:jessie] PASSED

--- a/doc/source/invocation.rst
+++ b/doc/source/invocation.rst
@@ -10,7 +10,7 @@ test remotes systems using `paramiko <http://www.paramiko.org>`_ (a
 ssh implementation in python)::
 
     $ pip install paramiko
-    $ testinfra -v --hosts=localhost,root@webserver:2222 test_myinfra.py
+    $ py.test -v --hosts=localhost,root@webserver:2222 test_myinfra.py
 
     ====================== test session starts ======================
     platform linux -- Python 2.7.3 -- py-1.4.26 -- pytest-2.6.4
@@ -45,7 +45,7 @@ If you have a lot of tests, you can use the pytest-xdist_ plugin to run tests us
     $ pip install pytest-xdist
 
     # Launch tests using 3 processes
-    $ testinfra -n 3 -v --host=web1,web2,web3,web4,web5,web6 test_myinfra.py
+    $ py.test -n 3 -v --host=web1,web2,web3,web4,web5,web6 test_myinfra.py
 
 
 Advanced invocation
@@ -54,10 +54,10 @@ Advanced invocation
 ::
 
     # Test recursively all test files (starting with `test_`) in current directory
-    $ testinfra
+    $ py.test
 
     # Filter function/hosts with pytest -k option
-    $ testinfra --hosts=webserver,dnsserver -k webserver -k nginx
+    $ py.test --hosts=webserver,dnsserver -k webserver -k nginx
 
 
 For more usages and features, see the Pytest_ documentation.

--- a/testinfra/main.py
+++ b/testinfra/main.py
@@ -11,87 +11,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import shutil
-import sys
-import tempfile
-import time
+import warnings
 
 import pytest
 
 
-class NagiosReporter(object):
-
-    def __init__(self):
-        self.passed = 0
-        self.failed = 0
-        self.skipped = 0
-        self.start_time = None
-        self.total_time = None
-        super(NagiosReporter, self).__init__()
-
-    def pytest_sessionstart(self, session):
-        self.start_time = time.time()
-
-    def pytest_sessionfinish(self):
-        self.total_time = time.time() - self.start_time
-
-    def pytest_runtest_logreport(self, report):
-        if report.passed:
-            if report.when == "call":  # ignore setup/teardown
-                self.passed += 1
-        elif report.failed:
-            self.failed += 1
-        elif report.skipped:
-            self.skipped += 1
-
-    def report(self):
-        if self.failed:
-            status = "CRITICAL"
-            ret = 2
-        else:
-            status = "OK"
-            ret = 0
-
-        sys.stdout.write((
-            b"TESTINFRA %s - %d passed, %d failed, %d skipped in %.2f "
-            b"seconds\n") % (
-                status, self.passed, self.failed, self.skipped, self.total_time
-            ))
-        return ret
-
-
-class RedirectStdStreams(object):
-    # http://stackoverflow.com/questions/6796492/temporarily-redirect-stdout-stderr
-    def __init__(self, stdout=None, stderr=None):
-        self._stdout = stdout or sys.stdout
-        self._stderr = stderr or sys.stderr
-        self._old_stdout = None
-        self._old_stderr = None
-        super(RedirectStdStreams, self).__init__()
-
-    def __enter__(self):
-        self._old_stdout, self._old_stderr = sys.stdout, sys.stderr
-        self._old_stdout.flush()
-        self._old_stderr.flush()
-        sys.stdout, sys.stderr = self._stdout, self._stderr
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        self._stdout.flush()
-        self._stderr.flush()
-        sys.stdout = self._old_stdout
-        sys.stderr = self._old_stderr
-
-
 def main():
-    if "--nagios" in sys.argv:
-        out = tempfile.SpooledTemporaryFile()
-        # Compat: In 2.7 SpooledTemporaryFile has no encoding param
-        out.encoding = sys.stdout.encoding
-        nagios_reporter = NagiosReporter()
-        with RedirectStdStreams(stdout=out, stderr=out):
-            pytest.main(plugins=[nagios_reporter])
-        ret = nagios_reporter.report()
-        out.seek(0)
-        shutil.copyfileobj(out, sys.stdout)
-        return ret
+    warnings.warn('calling testinfra is deprecated, call py.test instead')
     return pytest.main()


### PR DESCRIPTION
When using testinfra command, an anoying warning "Module already
imported so can not be re-written: testinfra" is displayed.

The only reason of the existence of testinfra command as a wrapper for
pytest was handling '--nagios' option that capture py.test output and
display nagios plugin compatible output *before* pytest test report.

This is now fixed by switching the output file of pytest's
terminalreporter to a in-memory temporary file.

Since the --nagios option work with py.test command, deprecate testinfra
command since it become useless and generate an anoying warning.

Closes #135