### PR TITLE
[docs] Update --nagios documentation to remove tracebacks

### DIFF
--- a/doc/source/examples.rst
+++ b/doc/source/examples.rst
@@ -125,14 +125,14 @@ monitoring checks, so let's push them to `Nagios <https://www.nagios.org/>`_ !
 Testinfra has an option `--nagios` that enable a compatible nagios plugin
 beharvior::
 
-    $ py.test -qq --nagios test_ok.py; echo $?
+    $ py.test -qq --nagios --tb none test_ok.py; echo $?
     TESTINFRA OK - 2 passed, 0 failed, 0 skipped in 2.30 seconds
-    [...]
+    ..
     0
 
-    $ py.test -qq --nagios test_fail.py; echo $?
+    $ py.test -qq --nagios --tb none test_fail.py; echo $?
     TESTINFRA CRITICAL - 1 passed, 1 failed, 0 skipped in 2.24 seconds
-    [Traceback that explain the failed test]
+    .F
     2
 
 

--- a/doc/source/examples.rst
+++ b/doc/source/examples.rst
@@ -125,12 +125,12 @@ monitoring checks, so let's push them to `Nagios <https://www.nagios.org/>`_ !
 Testinfra has an option `--nagios` that enable a compatible nagios plugin
 beharvior::
 
-    $ py.test -qq --nagios --tb none test_ok.py; echo $?
+    $ py.test -qq --nagios --tb line test_ok.py; echo $?
     TESTINFRA OK - 2 passed, 0 failed, 0 skipped in 2.30 seconds
     ..
     0
 
-    $ py.test -qq --nagios --tb none test_fail.py; echo $?
+    $ py.test -qq --nagios --tb line test_fail.py; echo $?
     TESTINFRA CRITICAL - 1 passed, 1 failed, 0 skipped in 2.24 seconds
     .F
     2

--- a/doc/source/examples.rst
+++ b/doc/source/examples.rst
@@ -133,6 +133,7 @@ beharvior::
     $ py.test -qq --nagios --tb line test_fail.py; echo $?
     TESTINFRA CRITICAL - 1 passed, 1 failed, 0 skipped in 2.24 seconds
     .F
+    /usr/lib/python3/dist-packages/example/example.py:95: error: [Errno 111] error msg
     2
 
 


### PR DESCRIPTION
I don't often see very verbose outputs to nrpe checks, so I would recommend using --tb none for that. (The operator can then go and run the test manually to get more information)