### PR TITLE
SystemInfo: drop undocumented methods

### DIFF
--- a/testinfra/modules/systeminfo.py
+++ b/testinfra/modules/systeminfo.py
@@ -139,23 +139,3 @@ class SystemInfo(InstanceModule):
         'wheezy'
         """
         return self.sysinfo["codename"]
-
-    @property
-    def user(self):
-        return self.check_output("id -nu")
-
-    @property
-    def uid(self):
-        return int(self.check_output("id -u"))
-
-    @property
-    def group(self):
-        return self.check_output("id -ng")
-
-    @property
-    def gid(self):
-        return int(self.check_output("id -g"))
-
-    @property
-    def hostname(self):
-        return self.check_output("hostname -s")


### PR DESCRIPTION
Drop user, uid, group, gid and hostname from SystemInfo module.
They where added by mistake in 5dce243035b521b03f5ab3509b0860710b16551a
and are not part of the public api (undocumented).

Closes #260