### PR TITLE
Fix for 'linked_to' test for MacOS

### DIFF
--- a/testinfra/modules/file.py
+++ b/testinfra/modules/file.py
@@ -267,6 +267,24 @@ class BSDFile(File):
         return self.check_output(
             "sha256 < %s", self.path)
 
+    @property
+    def linked_to(self):
+        link_script = '''
+        TARGET_FILE='{0}'
+        cd `dirname $TARGET_FILE`
+        TARGET_FILE=`basename $TARGET_FILE`
+        while [ -L "$TARGET_FILE" ]
+        do
+            TARGET_FILE=`readlink $TARGET_FILE`
+            cd `dirname $TARGET_FILE`
+            TARGET_FILE=`basename $TARGET_FILE`
+        done
+        PHYS_DIR=`pwd -P`
+        RESULT=$PHYS_DIR/$TARGET_FILE
+        echo $RESULT
+        '''.format(self.path)
+        return self.check_output(link_script)
+
 
 class NetBSDFile(BSDFile):
 

--- a/testinfra/modules/file.py
+++ b/testinfra/modules/file.py
@@ -177,9 +177,10 @@ class File(Module):
             return GNUFile
         elif host.system_info.type == "netbsd":
             return NetBSDFile
-        elif (host.system_info.type.endswith("bsd")
-                or host.system_info.type == "darwin"):
+        elif host.system_info.type.endswith("bsd"):
             return BSDFile
+        elif host.system_info.type == "darwin":
+            return DarwinFile
         else:
             raise NotImplementedError
 
@@ -266,6 +267,9 @@ class BSDFile(File):
     def sha256sum(self):
         return self.check_output(
             "sha256 < %s", self.path)
+
+
+class DarwinFile(BSDFile):
 
     @property
     def linked_to(self):


### PR DESCRIPTION
While running testinfra against a Mac OS system, I noticed that
the `linked_to` test uses `readlink -f` to evaluate a canonicalized
real path by recursively following all symlinks. Though this behavior
works with GNU's `readlink`, it does not work the same way for BSD's
version. In fact, it errors out because BSD's `readlink` does not
understand the `-f` flag.

It is possible to install the GNU equivalent for `readlink` on MacOS
via Homebrew. However, it seems like poor design to force this method
to have a dependency on Homebrew.

I found a StackOverflow post showing how to recreate the behavior of
GNU's `readlink` using BSD's `readlink`. This change is based on the
solution provided in that post, which fixes the behavior of the
`linked_to` test for systems using the BSD version of `readlink`
(e.g. MacOS). It should behave just like `readlink -f` on Linux systems.

Reference: https://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac