### PR TITLE
Feature: Add is_valid method to systemd.

### DIFF
--- a/testinfra/modules/service.py
+++ b/testinfra/modules/service.py
@@ -125,9 +125,8 @@ class SystemdService(SysvService):
         # stdout for anything.  Nothing means no warns/errors.
         # Docs at https://www.freedesktop.org/software/systemd/man/systemd
         # -analyze.html#Examples%20for%20verify
-        if not cmd.stdout and not cmd.stderr:
-            return True
-        return False
+        assert (cmd.stdout, cmd.stderr) == ("", "")
+        return True
 
 
 class UpstartService(SysvService):

--- a/testinfra/modules/service.py
+++ b/testinfra/modules/service.py
@@ -113,6 +113,22 @@ class SystemdService(SysvService):
         # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=760616
         return super(SystemdService, self).is_enabled
 
+    @property
+    def is_valid(self):
+        # systemd-analyze requires a full path.
+        if self.name.endswith(".service"):
+            name = self.name
+        else:
+            name = self.name + ".service"
+        cmd = self.run("systemd-analyze verify %s", name)
+        # A bad unit file still returns a rc of 0, so check the
+        # stdout for anything.  Nothing means no warns/errors.
+        # Docs at https://www.freedesktop.org/software/systemd/man/systemd
+        # -analyze.html#Examples%20for%20verify
+        if not cmd.stdout and not cmd.stderr:
+            return True
+        return False
+
 
 class UpstartService(SysvService):
 


### PR DESCRIPTION
After deploying some new service overrides I realised I'd made a spelling mistake in one of the fields, this should catch these by asserting there's no warnings.

I've tested these manually on a linux box, should be simple for you to do, just add a junk field to the unit file and it should now fail.

Open to name changes on `is_valid`, it seemed most in keeping with the package names.  Unsure where to add docs as well?