### PR TITLE
Change check_all to check_call in doc example

### DIFF
--- a/doc/source/examples.rst
+++ b/doc/source/examples.rst
@@ -172,7 +172,7 @@ fixture.
         # return a testinfra connection to the container
         yield testinfra.get_host("docker://" + docker_id)
         # at the end of the test suite, destroy the container
-        subprocess.check_all(['docker', 'rm', '-f', docker_id])
+        subprocess.check_call(['docker', 'rm', '-f', docker_id])
 
 
     def test_myimage(host):


### PR DESCRIPTION
I was experimenting with the docker examples and noticed that there appeared to be typo - it looks like subprocess.check_all(...) should actually be subprocess.check_call(...)