### PR TITLE
Use HTTPS protocol when specified in WinRM backend

### DIFF
--- a/testinfra/backend/winrm.py
+++ b/testinfra/backend/winrm.py
@@ -68,7 +68,7 @@ class WinRMBackend(base.BaseBackend):
         self.host = self.parse_hostspec(hostspec)
         self.conn_args = {
             'endpoint': '{}://{}{}/wsman'.format(
-                'http' if no_ssl else 'http',
+                'http' if no_ssl else 'https',
                 self.host.name,
                 ':{}'.format(self.host.port) if self.host.port else ''),
             'transport': 'ntlm',


### PR DESCRIPTION
Hello,

It seems there is a typo in the WinRM backend that prevents it to connect to WinRM services over HTTPS.

This change fixed the issue against our environment.

Remote host: AWS Windows server 2016 base 10, version 2018.03.24
Testinfra host: Ubuntu Linux 16.04, python 3.6

Example PowerShell script to configure WinRM service with HTTPS:  https://github.com/PeteGoo/packer-win-aws/blob/master/ec2-userdata.ps1