### PR TITLE
Convert GSSAPI variable to lowercase

### DIFF
--- a/testinfra/backend/paramiko.py
+++ b/testinfra/backend/paramiko.py
@@ -76,9 +76,9 @@ class ParamikoBackend(base.BaseBackend):
                     if cfg[key] in ('yes', 'force'):
                         self.get_pty = True
                 elif key == "GSSAPIKeyExchange":
-                    cfg['gss_auth'] = True if value is 'yes' else False
+                    cfg['gss_auth'] = (value == 'yes')
                 elif key == "GSSAPIAuthentication":
-                    cfg['gss_kex'] = True if value is 'yes' else False
+                    cfg['gss_kex'] = (value == 'yes')
         if self.ssh_identity_file:
             cfg["key_filename"] = self.ssh_identity_file
         client.connect(**cfg)

--- a/testinfra/backend/paramiko.py
+++ b/testinfra/backend/paramiko.py
@@ -75,9 +75,9 @@ class ParamikoBackend(base.BaseBackend):
                 elif key == "requesttty":
                     if cfg[key] in ('yes', 'force'):
                         self.get_pty = True
-                elif key == "GSSAPIKeyExchange":
+                elif key == "gssapikeyexchange":
                     cfg['gss_auth'] = (value == 'yes')
-                elif key == "GSSAPIAuthentication":
+                elif key == "gssapiauthentication":
                     cfg['gss_kex'] = (value == 'yes')
         if self.ssh_identity_file:
             cfg["key_filename"] = self.ssh_identity_file

--- a/testinfra/backend/paramiko.py
+++ b/testinfra/backend/paramiko.py
@@ -75,6 +75,10 @@ class ParamikoBackend(base.BaseBackend):
                 elif key == "requesttty":
                     if cfg[key] in ('yes', 'force'):
                         self.get_pty = True
+                elif key == "GSSAPIKeyExchange":
+                    cfg['gss_auth'] = True if value is 'yes' else False
+                elif key == "GSSAPIAuthentication":
+                    cfg['gss_kex'] = True if value is 'yes' else False
         if self.ssh_identity_file:
             cfg["key_filename"] = self.ssh_identity_file
         client.connect(**cfg)


### PR DESCRIPTION
Variables are getting converted to lowercase while parsed in the key=>value dictionary, therefore ignoring the GSSAPI check