### PR TITLE
Socket: fix detection of udp listening sockets

### DIFF
--- a/testinfra/modules/socket.py
+++ b/testinfra/modules/socket.py
@@ -238,7 +238,8 @@ class LinuxSocketSS(Socket):
                 port = int(port)
             else:
                 continue
-            if listening and status == 'LISTEN':
+            # udp listening sockets may be in 'UNCONN' status
+            if listening and status in ('LISTEN', 'UNCONN'):
                 if host == '*':
                     yield protocol, '::', port
                     yield protocol, '0.0.0.0', port


### PR DESCRIPTION
They are reported as 'UNCONN' in 'ss -l -u -n' output.

Closes #311