### PR TITLE
Fix test generation with ansible and xdist

### DIFF
--- a/testinfra/plugin.py
+++ b/testinfra/plugin.py
@@ -146,7 +146,7 @@ def pytest_generate_tests(metafunc):
             sudo_user=metafunc.config.option.sudo_user,
             ansible_inventory=metafunc.config.option.ansible_inventory,
         )
-        ids = [e.backend.get_pytest_id() for e in params]
+        ids = sorted([e.backend.get_pytest_id() for e in params])
         metafunc.parametrize(
             "_testinfra_host", params, ids=ids, scope="module")
 


### PR DESCRIPTION
It appears that a change in ansible 2.5.1 caused hosts in the inventory
to be returned in a non-deterministic order. When using testinfra with
pytest-xdist, that can result in a failure during test collection:

    "Different tests were collected between gwX and gwY"

Simply sorting our hosts fixes this issue.

Example of the failure:
```
$ cat test.py
#!/usr/bin/env python

testinfra_hosts = ['!group_b']


class TestXdist(object):
    def test_one(self, host):
        assert True

    def test_two(self, host):
        assert True

    def test_three(self, host):
        assert True
$ cat inventory/test
[group_a]
host_a_0

[group_b]
host_b_0

[group_c]
host_c_0

[group_d]
host_d_0

[group_e]
host_e_0
$ py.test -v -n auto --connection=ansible --ansible-inventory=./inventory ./test.py
============================================== test session starts ===============================================
platform darwin -- Python 2.7.14, pytest-3.5.1, py-1.5.3, pluggy-0.6.0 -- /Users/zack/testinfra_xdist_ansible/virtualenv/bin/python2.7
cachedir: .pytest_cache
rootdir: /Users/zack/testinfra_xdist_ansible, inifile:
plugins: testinfra-1.13.0, xdist-1.22.2, forked-0.2
[gw0] darwin Python 2.7.14 cwd: /Users/zack/testinfra_xdist_ansible
[gw1] darwin Python 2.7.14 cwd: /Users/zack/testinfra_xdist_ansible
[gw2] darwin Python 2.7.14 cwd: /Users/zack/testinfra_xdist_ansible
[gw3] darwin Python 2.7.14 cwd: /Users/zack/testinfra_xdist_ansible
[gw0] Python 2.7.14 (default, Mar 22 2018, 15:04:47)  -- [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
[gw1] Python 2.7.14 (default, Mar 22 2018, 15:04:47)  -- [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
[gw3] Python 2.7.14 (default, Mar 22 2018, 15:04:47)  -- [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
[gw2] Python 2.7.14 (default, Mar 22 2018, 15:04:47)  -- [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
gw0 [12] / gw1 [12] / gw2 [12] / gw3 [12]
scheduling tests via LoadScheduling
collecting 0 items / 2 errors
===================================================== ERRORS =====================================================
______________________________________________ ERROR collecting gw1 ______________________________________________
Different tests were collected between gw2 and gw1. The difference is:
--- gw2

+++ gw1

@@ -4,9 +4,9 @@

 test.py::TestXdist::()::test_one[ansible://host_a_0]
 test.py::TestXdist::()::test_two[ansible://host_a_0]
 test.py::TestXdist::()::test_three[ansible://host_a_0]
+test.py::TestXdist::()::test_one[ansible://host_c_0]
+test.py::TestXdist::()::test_two[ansible://host_c_0]
+test.py::TestXdist::()::test_three[ansible://host_c_0]
 test.py::TestXdist::()::test_one[ansible://host_e_0]
 test.py::TestXdist::()::test_two[ansible://host_e_0]
 test.py::TestXdist::()::test_three[ansible://host_e_0]
-test.py::TestXdist::()::test_one[ansible://host_c_0]
-test.py::TestXdist::()::test_two[ansible://host_c_0]
-test.py::TestXdist::()::test_three[ansible://host_c_0]
______________________________________________ ERROR collecting gw0 ______________________________________________
Different tests were collected between gw2 and gw0. The difference is:
--- gw2

+++ gw0

@@ -1,12 +1,12 @@

 test.py::TestXdist::()::test_one[ansible://host_d_0]
 test.py::TestXdist::()::test_two[ansible://host_d_0]
 test.py::TestXdist::()::test_three[ansible://host_d_0]
+test.py::TestXdist::()::test_one[ansible://host_e_0]
+test.py::TestXdist::()::test_two[ansible://host_e_0]
+test.py::TestXdist::()::test_three[ansible://host_e_0]
 test.py::TestXdist::()::test_one[ansible://host_a_0]
 test.py::TestXdist::()::test_two[ansible://host_a_0]
 test.py::TestXdist::()::test_three[ansible://host_a_0]
-test.py::TestXdist::()::test_one[ansible://host_e_0]
-test.py::TestXdist::()::test_two[ansible://host_e_0]
-test.py::TestXdist::()::test_three[ansible://host_e_0]
 test.py::TestXdist::()::test_one[ansible://host_c_0]
 test.py::TestXdist::()::test_two[ansible://host_c_0]
 test.py::TestXdist::()::test_three[ansible://host_c_0]
============================================ 2 error in 1.56 seconds =============================================
```