### PR TITLE
Add namespace support for kubectl connector.

### DIFF
--- a/doc/source/backends.rst
+++ b/doc/source/backends.rst
@@ -91,10 +91,15 @@ Note: Ansible settings such as ``remote_user``, etc., may be configured by using
 kubectl
 ~~~~~~~
 
-The kubectl backend can be used to test containers running in Kubernetes.
-It uses the `kubectl exec <http://kubernetes.io/docs/user-guide/kubectl/kubectl_exec/>`_ command::
+The kubectl backend can be used to test containers running in Kubernetes.  It
+uses the `kubectl exec <http://kubernetes.io/docs/user-guide/kubectl/kubectl_exec/>`_ command and
+support connecting to a given container name within a pod and using a given
+namespace::
 
-    $ py.test --connection=kubectl --hosts=pod_id-123456789-9fng/container_name
+    # will use the default namespace and default container
+    $ py.test --hosts='kubectl://mypod-a1b2c3'
+    # specify container name and namespace
+    $ py.test --hosts='kubectl://somepod-2536ab?container=nginx&namespace=web'
 
 
 winrm

--- a/images/centos_6/Dockerfile
+++ b/images/centos_6/Dockerfile
@@ -1,0 +1,17 @@
+FROM centos:6
+
+RUN yum clean all && \
+    yum -y install \
+      openssh-server && \
+    rm -f /etc/ssh/ssh_host_ecdsa_key /etc/ssh/ssh_host_rsa_key && \
+    ssh-keygen -q -N "" -t dsa -f /etc/ssh/ssh_host_ecdsa_key && \
+    ssh-keygen -q -N "" -t rsa -f /etc/ssh/ssh_host_rsa_key && \
+    sed -i "s/#UsePrivilegeSeparation.*/UsePrivilegeSeparation no/g" /etc/ssh/sshd_config && \
+    chkconfig sshd on && \
+    service sshd start && \
+    mkdir -p /root/.ssh && \
+    echo "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCgDryK4AjJeifuc2N54St13KMNlnGLAtibQSMmvSyrhH7XJ1atnBo1HrJhGZNNBVKM67+zYNc9J3fg3qI1g63vSQAA+nXMsDYwu4BPwupakpwJELcGZJxsUGzjGVotVpqPIX5nW8NBGvkVuObI4UELOleq5mQMTGerJO64KkSVi20FDwPJn3q8GG2zk3pESiDA5ShEyFhYC8vOLfSSYD0LYmShAVGCLEgiNb+OXQL6ZRvzqfFEzL0QvaI/l3mb6b0VFPAO4QWOL0xj3cWzOZXOqht3V85CZvSk8ISdNgwCjXLZsPeaYL/toHNvBF30VMrDZ7w4SDU0ZZLEsc/ezxjb" > /root/.ssh/authorized_keys
+
+VOLUME ["/sys/fs/cgroup"]
+EXPOSE 22
+CMD ["/usr/sbin/sshd", "-D"]

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -65,6 +65,7 @@ ANSIBLE_HOSTVARS = """$ANSIBLE_VAULT;1.1;AES256
 DOCKER_IMAGES = [
     "alpine_35",
     "archlinux",
+    "centos_6",
     "centos_7",
     "debian_stretch",
     "fedora",
@@ -202,7 +203,15 @@ def host(request, tmpdir_factory):
         service = testinfra.get_host(
             docker_id, connection='docker').service
 
-        if image in ("centos_7", "fedora", "alpine_35", "archlinux"):
+        images_with_sshd = (
+            "centos_6",
+            "centos_7",
+            "fedora",
+            "alpine_35",
+            "archlinux"
+        )
+
+        if image in images_with_sshd:
             service_name = "sshd"
         else:
             service_name = "ssh"

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -248,6 +248,7 @@ def pytest_generate_tests(metafunc):
 
 
 def pytest_configure(config):
+    return
     if not has_docker():
         return
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -248,7 +248,6 @@ def pytest_generate_tests(metafunc):
 
 
 def pytest_configure(config):
-    return
     if not has_docker():
         return
 

--- a/test/test_backends.py
+++ b/test/test_backends.py
@@ -113,6 +113,18 @@ def test_parse_hostspec(hostspec, expected):
     assert BaseBackend.parse_hostspec(hostspec) == expected
 
 
+@pytest.mark.parametrize('hostspec,pod,container,namespace', [
+    ('kubectl://pod', 'pod', None, None),
+    ('kubectl://pod?namespace=n', 'pod', None, 'n'),
+    ('kubectl://pod?container=c&namespace=n', 'pod', 'c', 'n'),
+])
+def test_kubectl_hostspec(hostspec, pod, container, namespace):
+    backend = testinfra.get_host(hostspec).backend
+    assert backend.name == pod
+    assert backend.container == container
+    assert backend.namespace == namespace
+
+
 @pytest.mark.parametrize('arg_string,expected', [
     (
         'C:\\Users\\vagrant\\This Dir\\salt',

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -23,7 +23,7 @@ from testinfra.modules.socket import parse_socketspec
 all_images = pytest.mark.testinfra_hosts(*[
     "docker://{}".format(image)
     for image in (
-        "alpine_35", "archlinux", "centos_7",
+        "alpine_35", "archlinux", "centos_6", "centos_7",
         "debian_stretch", "fedora", "ubuntu_xenial"
     )
 ])
@@ -41,6 +41,7 @@ def test_package(host, docker_image):
     version = {
         "alpine_35": "7.",
         "archlinux": "7.",
+        "centos_6": "5.",
         "centos_7": "7.",
         "debian_stretch": "1:7.4",
         "fedora": "7.",
@@ -51,6 +52,7 @@ def test_package(host, docker_image):
     release = {
         "alpine_35": "r1",
         "archlinux": None,
+        "centos_6": ".el6",
         "centos_7": ".el7",
         "debian_stretch": None,
         "fedora": ".fc27",
@@ -90,6 +92,7 @@ def test_systeminfo(host, docker_image):
     release, distribution, codename = {
         "alpine_35": ("^3\.5\.", "alpine", None),
         "archlinux": ("rolling", "arch", None),
+        "centos_6": (r"^6", "CentOS", None),
         "centos_7": ("^7$", "centos", None),
         "debian_stretch": ("^9\.", "debian", "stretch"),
         "fedora": ("^27$", "fedora", None),
@@ -103,7 +106,8 @@ def test_systeminfo(host, docker_image):
 
 @all_images
 def test_ssh_service(host, docker_image):
-    if docker_image in ("centos_7", "fedora", "alpine_35", "archlinux"):
+    if docker_image in ("centos_6", "centos_7", "fedora",
+                        "alpine_35", "archlinux"):
         name = "sshd"
     else:
         name = "ssh"
@@ -202,6 +206,7 @@ def test_process(host, docker_image):
     args, comm = {
         "alpine_35": ("/sbin/init", "init"),
         "archlinux": ("/usr/sbin/init", "systemd"),
+        "centos_6": ("/usr/sbin/sshd -D", "sshd"),
         "centos_7": ("/usr/sbin/init", "systemd"),
         "debian_stretch": ("/sbin/init", "systemd"),
         "fedora": ("/usr/sbin/init", "systemd"),

--- a/testinfra/backend/__init__.py
+++ b/testinfra/backend/__init__.py
@@ -46,9 +46,6 @@ def parse_hostspec(hostspec):
         url = urllib.parse.urlparse(hostspec)
         kw["connection"] = url.scheme
         host = url.netloc
-        path = url.path
-        if path:
-            kw['container'] = path[1:]
         query = urllib.parse.parse_qs(url.query)
         for key in ('sudo', 'ssl', 'verify_ssl'):
             if query.get(key, ['false'])[0].lower() == 'true':

--- a/testinfra/backend/ansible.py
+++ b/testinfra/backend/ansible.py
@@ -20,7 +20,6 @@ import pprint
 from testinfra.backend import base
 from testinfra.utils.ansible_runner import AnsibleRunner
 from testinfra.utils.ansible_runner import to_bytes
-from testinfra.utils import cached_property
 
 logger = logging.getLogger("testinfra")
 
@@ -34,9 +33,9 @@ class AnsibleBackend(base.BaseBackend):
         self.ansible_inventory = ansible_inventory
         super(AnsibleBackend, self).__init__(host, *args, **kwargs)
 
-    @cached_property
+    @property
     def ansible_runner(self):
-        return AnsibleRunner(self.ansible_inventory)
+        return AnsibleRunner.get_runner(self.ansible_inventory)
 
     def run(self, command, *args, **kwargs):
         command = self.get_command(command, *args)
@@ -67,4 +66,5 @@ class AnsibleBackend(base.BaseBackend):
 
     @classmethod
     def get_hosts(cls, host, **kwargs):
-        return AnsibleRunner(kwargs.get("ansible_inventory")).get_hosts(host)
+        inventory = kwargs.get('ansible_inventory')
+        return AnsibleRunner.get_runner(inventory).get_hosts(host)

--- a/testinfra/backend/base.py
+++ b/testinfra/backend/base.py
@@ -204,14 +204,6 @@ class BaseBackend(object):
             user, name = name.split("@", 1)
         return name, user
 
-    @staticmethod
-    def parse_podspec(podspec):
-        name = podspec
-        container = None
-        if "/" in name:
-            name, container = name.split("/", 1)
-        return name, container
-
     def get_encoding(self):
         cmd = self.run(
             "python -c 'import locale;print(locale.getpreferredencoding())'")

--- a/testinfra/backend/kubectl.py
+++ b/testinfra/backend/kubectl.py
@@ -21,41 +21,24 @@ class KubectlBackend(base.BaseBackend):
     NAME = "kubectl"
 
     def __init__(self, name, *args, **kwargs):
-        self.container = None
-        self.name, self.container = self.parse_podspec(name)
-
-        if kwargs:
-            if "namespace" in kwargs:
-                self.namespace = kwargs.get('namespace')
-            if "container" in kwargs:
-                self.container = kwargs.get('container')
-
-        if "/" in self.name:
-            self.name, self.container = self.name.split("/", 1)
-
+        self.name = name
+        self.container = kwargs.get('container')
+        self.namespace = kwargs.get('namespace')
         super(KubectlBackend, self).__init__(self.name, *args, **kwargs)
 
     def run(self, command, *args, **kwargs):
         cmd = self.get_command(command, *args)
         # `kubectl exec` does not support specifying the user to run as.
         # See https://github.com/kubernetes/kubernetes/issues/30656
-        if self.container is None:
-            if self.namespace:
-                out = self.run_local(
-                    "kubectl -n %s exec %s -- /bin/sh -c %s",
-                    self.namespace, self.name, cmd)
-            else:
-                out = self.run_local(
-                    "kubectl exec %s -- /bin/sh -c %s",
-                    self.name, cmd)
-        else:
-            if self.namespace:
-                out = self.run_local(
-                    "kubectl -n %s exec %s -c %s -- /bin/sh -c %s",
-                    self.namespace, self.name, self.container, cmd)
-            else:
-                out = self.run_local(
-                    "kubectl exec %s -c %s -- /bin/sh -c %s",
-                    self.name, self.container, cmd)
-        out.command = self.encode(cmd)
+        kcmd = 'kubectl '
+        kcmd_args = []
+        if self.namespace is not None:
+            kcmd += '-n %s '
+            kcmd_args.append(self.namespace)
+        if self.container is not None:
+            kcmd += '-c %s '
+            kcmd_args.append(self.container)
+        kcmd += 'exec %s -- /bin/sh -c %s'
+        kcmd_args.extend([self.name, cmd])
+        out = self.run_local(kcmd, *kcmd_args)
         return out

--- a/testinfra/modules/service.py
+++ b/testinfra/modules/service.py
@@ -93,7 +93,7 @@ class SysvService(Service):
     @property
     def is_enabled(self):
         return bool(self.check_output(
-            "find /etc/rc?.d/ -name %s",
+            "find -L /etc/rc?.d/ -name %s",
             "S??" + self.name,
         ))
 

--- a/testinfra/utils/ansible_runner.py
+++ b/testinfra/utils/ansible_runner.py
@@ -53,6 +53,7 @@ __all__ = ['AnsibleRunner', 'to_bytes']
 
 
 class AnsibleRunnerBase(object):
+    _runners = {}
 
     def __init__(self, host_list=None):
         self.host_list = host_list
@@ -66,6 +67,14 @@ class AnsibleRunnerBase(object):
 
     def run(self, host, module_name, module_args, **kwargs):
         raise NotImplementedError
+
+    @classmethod
+    def get_runner(cls, inventory):
+        try:
+            return cls._runners[inventory]
+        except KeyError:
+            cls._runners[inventory] = cls(inventory)
+            return cls._runners[inventory]
 
 
 class AnsibleRunnerV1(AnsibleRunnerBase):

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ deps=
 commands=
     py.test {posargs:-v -k ansible test}
 usedevelop=True
-passenv=HOME TRAVIS
+passenv=HOME TRAVIS DOCKER_CERT_PATH DOCKER_HOST DOCKER_TLS_VERIFY
 
 [testenv:flake8]
 basepython=python3


### PR DESCRIPTION
usage: py.test --connection=kubectl --hosts=<pod-name>[/<image-name>][%<namespace>] ...

where namespace is the k8s namespace where you work inside.
So it's not necassary to switch the default namespace from your kubectl client installation
to access/work with a specific namespace