### PR TITLE
Share runners (and parsed inventory) among hosts

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+1.13.1
+======
+
+* package: fix is_installed and version behavior for uninstalled packages (#321 and #326)
+* ansible: Use predictibles test ordering when using pytest-xdist to fix random test collections errors (#316)
+
 1.13.0
 ======
 

--- a/images/centos_6/Dockerfile
+++ b/images/centos_6/Dockerfile
@@ -1,0 +1,17 @@
+FROM centos:6
+
+RUN yum clean all && \
+    yum -y install \
+      openssh-server && \
+    rm -f /etc/ssh/ssh_host_ecdsa_key /etc/ssh/ssh_host_rsa_key && \
+    ssh-keygen -q -N "" -t dsa -f /etc/ssh/ssh_host_ecdsa_key && \
+    ssh-keygen -q -N "" -t rsa -f /etc/ssh/ssh_host_rsa_key && \
+    sed -i "s/#UsePrivilegeSeparation.*/UsePrivilegeSeparation no/g" /etc/ssh/sshd_config && \
+    chkconfig sshd on && \
+    service sshd start && \
+    mkdir -p /root/.ssh && \
+    echo "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCgDryK4AjJeifuc2N54St13KMNlnGLAtibQSMmvSyrhH7XJ1atnBo1HrJhGZNNBVKM67+zYNc9J3fg3qI1g63vSQAA+nXMsDYwu4BPwupakpwJELcGZJxsUGzjGVotVpqPIX5nW8NBGvkVuObI4UELOleq5mQMTGerJO64KkSVi20FDwPJn3q8GG2zk3pESiDA5ShEyFhYC8vOLfSSYD0LYmShAVGCLEgiNb+OXQL6ZRvzqfFEzL0QvaI/l3mb6b0VFPAO4QWOL0xj3cWzOZXOqht3V85CZvSk8ISdNgwCjXLZsPeaYL/toHNvBF30VMrDZ7w4SDU0ZZLEsc/ezxjb" > /root/.ssh/authorized_keys
+
+VOLUME ["/sys/fs/cgroup"]
+EXPOSE 22
+CMD ["/usr/sbin/sshd", "-D"]

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -65,6 +65,7 @@ ANSIBLE_HOSTVARS = """$ANSIBLE_VAULT;1.1;AES256
 DOCKER_IMAGES = [
     "alpine_35",
     "archlinux",
+    "centos_6",
     "centos_7",
     "debian_stretch",
     "fedora",
@@ -202,7 +203,15 @@ def host(request, tmpdir_factory):
         service = testinfra.get_host(
             docker_id, connection='docker').service
 
-        if image in ("centos_7", "fedora", "alpine_35", "archlinux"):
+        images_with_sshd = (
+            "centos_6",
+            "centos_7",
+            "fedora",
+            "alpine_35",
+            "archlinux"
+        )
+
+        if image in images_with_sshd:
             service_name = "sshd"
         else:
             service_name = "ssh"

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -202,7 +202,7 @@ def host(request, tmpdir_factory):
         service = testinfra.get_host(
             docker_id, connection='docker').service
 
-        if image in ("centos_7", "fedora"):
+        if image in ("centos_7", "fedora", "alpine_35", "archlinux"):
             service_name = "sshd"
         else:
             service_name = "ssh"

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -290,6 +290,9 @@ def test_file(host):
     assert l.is_symlink
     assert l.is_file
     assert l.linked_to == "/d/f"
+    assert l.linked_to == f
+    assert f == f
+    assert not d == f
 
     host.check_output("rm -f /d/p && mkfifo /d/p")
     assert host.file("/d/p").is_pipe

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -69,6 +69,20 @@ def test_held_package(host):
     assert python.version.startswith("2.7.")
 
 
+@pytest.mark.destructive
+def test_uninstalled_package_version(host):
+    with pytest.raises(AssertionError) as excinfo:
+        host.package('zsh').version
+    assert 'Unexpected exit code 1 for CommandResult' in str(excinfo.value)
+    assert host.package('sudo').is_installed
+    host.check_output('apt-get -y remove sudo')
+    assert not host.package('sudo').is_installed
+    with pytest.raises(AssertionError) as excinfo:
+        host.package('sudo').version
+    assert ('The package sudo is not installed, dpkg-query output: '
+            'deinstall ok config-files 1.8.') in str(excinfo.value)
+
+
 @all_images
 def test_systeminfo(host, docker_image):
     assert host.system_info.type == "linux"

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -31,6 +31,7 @@ all_images = pytest.mark.testinfra_hosts(*[
 
 @all_images
 def test_package(host, docker_image):
+    assert not host.package('zsh').is_installed
     if docker_image in ("alpine_35", "archlinux"):
         name = "openssh"
     else:

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -97,7 +97,8 @@ def test_ssh_service(host, docker_image):
     ssh = host.service(name)
     if docker_image == "ubuntu_xenial":
         assert not ssh.is_running
-    else:
+    # FIXME: is_running test is broken for archlinux for unknown reason
+    elif docker_image != "archlinux":
         assert ssh.is_running
 
     if docker_image == "ubuntu_xenial":

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -23,7 +23,7 @@ from testinfra.modules.socket import parse_socketspec
 all_images = pytest.mark.testinfra_hosts(*[
     "docker://{}".format(image)
     for image in (
-        "alpine_35", "archlinux", "centos_7",
+        "alpine_35", "archlinux", "centos_6", "centos_7",
         "debian_stretch", "fedora", "ubuntu_xenial"
     )
 ])
@@ -41,6 +41,7 @@ def test_package(host, docker_image):
     version = {
         "alpine_35": "7.",
         "archlinux": "7.",
+        "centos_6": "5.",
         "centos_7": "7.",
         "debian_stretch": "1:7.4",
         "fedora": "7.",
@@ -51,6 +52,7 @@ def test_package(host, docker_image):
     release = {
         "alpine_35": "r1",
         "archlinux": None,
+        "centos_6": ".el6",
         "centos_7": ".el7",
         "debian_stretch": None,
         "fedora": ".fc27",
@@ -90,6 +92,7 @@ def test_systeminfo(host, docker_image):
     release, distribution, codename = {
         "alpine_35": ("^3\.5\.", "alpine", None),
         "archlinux": ("rolling", "arch", None),
+        "centos_6": (r"^6", "CentOS", None),
         "centos_7": ("^7$", "centos", None),
         "debian_stretch": ("^9\.", "debian", "stretch"),
         "fedora": ("^27$", "fedora", None),
@@ -103,7 +106,8 @@ def test_systeminfo(host, docker_image):
 
 @all_images
 def test_ssh_service(host, docker_image):
-    if docker_image in ("centos_7", "fedora", "alpine_35", "archlinux"):
+    if docker_image in ("centos_6", "centos_7", "fedora",
+                        "alpine_35", "archlinux"):
         name = "sshd"
     else:
         name = "ssh"
@@ -202,6 +206,7 @@ def test_process(host, docker_image):
     args, comm = {
         "alpine_35": ("/sbin/init", "init"),
         "archlinux": ("/usr/sbin/init", "systemd"),
+        "centos_6": ("/usr/sbin/sshd -D", "sshd"),
         "centos_7": ("/usr/sbin/init", "systemd"),
         "debian_stretch": ("/sbin/init", "systemd"),
         "fedora": ("/usr/sbin/init", "systemd"),

--- a/testinfra/backend/ansible.py
+++ b/testinfra/backend/ansible.py
@@ -20,7 +20,6 @@ import pprint
 from testinfra.backend import base
 from testinfra.utils.ansible_runner import AnsibleRunner
 from testinfra.utils.ansible_runner import to_bytes
-from testinfra.utils import cached_property
 
 logger = logging.getLogger("testinfra")
 
@@ -29,16 +28,14 @@ class AnsibleBackend(base.BaseBackend):
     NAME = "ansible"
     HAS_RUN_ANSIBLE = True
 
-    _runners = {}
-
     def __init__(self, host, ansible_inventory=None, *args, **kwargs):
         self.host = host
         self.ansible_inventory = ansible_inventory
         super(AnsibleBackend, self).__init__(host, *args, **kwargs)
 
-    @cached_property
+    @property
     def ansible_runner(self):
-        return type(self).get_runner(self.ansible_inventory)
+        return AnsibleRunner.get_runner(self.ansible_inventory)
 
     def run(self, command, *args, **kwargs):
         command = self.get_command(command, *args)
@@ -68,13 +65,6 @@ class AnsibleBackend(base.BaseBackend):
         return self.ansible_runner.get_variables(self.host)
 
     @classmethod
-    def get_runner(cls, ansible_inventory):
-        runners = cls._runners
-        if ansible_inventory not in runners:
-            runners[ansible_inventory] = AnsibleRunner(ansible_inventory)
-        return runners[ansible_inventory]
-
-    @classmethod
     def get_hosts(cls, host, **kwargs):
-        runner = cls.get_runner(kwargs.get("ansible_inventory"))
-        return runner.get_hosts(host)
+        inventory = kwargs.get('ansible_inventory')
+        return AnsibleRunner.get_runner(inventory).get_hosts(host)

--- a/testinfra/modules/file.py
+++ b/testinfra/modules/file.py
@@ -14,6 +14,7 @@
 from __future__ import unicode_literals
 
 import datetime
+import six
 
 from testinfra.modules.base import Module
 
@@ -170,6 +171,16 @@ class File(Module):
 
     def __repr__(self):
         return "<file %s>" % (self.path,)
+
+    def __eq__(self, other):
+        if isinstance(other, File):
+            return self.path == other.path
+        elif isinstance(other, six.string_types):
+            return self.path == other
+        return False
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
     @classmethod
     def get_module_class(cls, host):

--- a/testinfra/modules/package.py
+++ b/testinfra/modules/package.py
@@ -85,8 +85,10 @@ class DebianPackage(Package):
 
     @property
     def is_installed(self):
-        out = self.check_output("dpkg-query -f '${Status}' -W %s" % (
-            self.name,)).split()
+        result = self.run_test("dpkg-query -f '${Status}' -W %s", self.name)
+        if result.rc == 1:
+            return False
+        out = result.stdout.strip().split()
         installed_status = ["ok", "installed"]
         return out[0] in ["install", "hold"] and out[1:3] == installed_status
 

--- a/testinfra/modules/package.py
+++ b/testinfra/modules/package.py
@@ -98,10 +98,13 @@ class DebianPackage(Package):
 
     @property
     def version(self):
-        out = self.check_output("dpkg-query -f '${Status} ${Version}' -W %s"
-                                % (self.name,)).split()
-        if out[0].lower() in ["install", "hold"]:
-            return out[3]
+        out = self.check_output("dpkg-query -f '${Status} ${Version}' -W %s",
+                                self.name)
+        splitted = out.split()
+        assert splitted[0].lower() in ('install', 'hold'), (
+            "The package %s is not installed, dpkg-query output: %s" % (
+                self.name, out))
+        return splitted[3]
 
 
 class FreeBSDPackage(Package):

--- a/testinfra/modules/service.py
+++ b/testinfra/modules/service.py
@@ -93,7 +93,7 @@ class SysvService(Service):
     @property
     def is_enabled(self):
         return bool(self.check_output(
-            "find /etc/rc?.d/ -name %s",
+            "find -L /etc/rc?.d/ -name %s",
             "S??" + self.name,
         ))
 

--- a/testinfra/utils/ansible_runner.py
+++ b/testinfra/utils/ansible_runner.py
@@ -53,6 +53,7 @@ __all__ = ['AnsibleRunner', 'to_bytes']
 
 
 class AnsibleRunnerBase(object):
+    _runners = {}
 
     def __init__(self, host_list=None):
         self.host_list = host_list
@@ -66,6 +67,14 @@ class AnsibleRunnerBase(object):
 
     def run(self, host, module_name, module_args, **kwargs):
         raise NotImplementedError
+
+    @classmethod
+    def get_runner(cls, inventory):
+        try:
+            return cls._runners[inventory]
+        except KeyError:
+            cls._runners[inventory] = cls(inventory)
+            return cls._runners[inventory]
 
 
 class AnsibleRunnerV1(AnsibleRunnerBase):

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ deps=
 commands=
     py.test {posargs:-v -k ansible test}
 usedevelop=True
-passenv=HOME TRAVIS
+passenv=HOME TRAVIS DOCKER_CERT_PATH DOCKER_HOST DOCKER_TLS_VERIFY
 
 [testenv:flake8]
 basepython=python3

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ deps=
     -rtest-requirements.txt
     ansible>=2.4,<3
 commands=
-    testinfra {posargs:-v -n 4 --cov testinfra --cov-report xml --cov-report term test}
+    py.test {posargs:-v -n 4 --cov testinfra --cov-report xml --cov-report term test}
 usedevelop=True
 passenv=HOME TRAVIS DOCKER_CERT_PATH DOCKER_HOST DOCKER_TLS_VERIFY
 
@@ -16,7 +16,7 @@ deps=
     -rtest-requirements.txt
     ansible>=1,<2
 commands=
-    testinfra {posargs:-v -k ansible test}
+    py.test {posargs:-v -k ansible test}
 usedevelop=True
 passenv=HOME TRAVIS
 


### PR DESCRIPTION
Presently, the caching applied to `AnsibleRunners` is only effective at
the host level -- meaning that while we'll only check the inventory once
per host, we cannot do it less often. With dynamic inventories that can
take multiple seconds to compute their value, this cost can become
expensive quickly.

This change moves the cache to the class level, so that we'll execute
the ansible inventory once per `ansible_inventory` argument and no more
often.

NB: if a client calls into AnsibleBackend using a relative path, changes
the working directory, and calls `get_hosts` again with the same
relative path, they'll get stale results.

That workflow seems unlikely, but it might be nice to at least log a message on cache hit so we can shorten the time to resolution in that situation – I haven't been successful in emitting a log message in AnsibleBackend that a person using `py.test` will see. Any tips?