### PR TITLE
Package: fix is_installed for non-installed packages on Debian

### DIFF
--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -31,6 +31,7 @@ all_images = pytest.mark.testinfra_hosts(*[
 
 @all_images
 def test_package(host, docker_image):
+    assert not host.package('zsh').is_installed
     if docker_image in ("alpine_35", "archlinux"):
         name = "openssh"
     else:

--- a/testinfra/modules/package.py
+++ b/testinfra/modules/package.py
@@ -85,8 +85,10 @@ class DebianPackage(Package):
 
     @property
     def is_installed(self):
-        out = self.check_output("dpkg-query -f '${Status}' -W %s" % (
-            self.name,)).split()
+        result = self.run_test("dpkg-query -f '${Status}' -W %s", self.name)
+        if result.rc == 1:
+            return False
+        out = result.stdout.strip().split()
         installed_status = ["ok", "installed"]
         return out[0] in ["install", "hold"] and out[1:3] == installed_status
 


### PR DESCRIPTION
Also add a test and avoid shell injections when running 'dpkg-query'

Closes #321