### PR TITLE
Package: fix version() behavior for uninstalled packages

### DIFF
--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -69,6 +69,20 @@ def test_held_package(host):
     assert python.version.startswith("2.7.")
 
 
+@pytest.mark.destructive
+def test_uninstalled_package_version(host):
+    with pytest.raises(AssertionError) as excinfo:
+        host.package('zsh').version
+    assert 'Unexpected exit code 1 for CommandResult' in str(excinfo.value)
+    assert host.package('sudo').is_installed
+    host.check_output('apt-get -y remove sudo')
+    assert not host.package('sudo').is_installed
+    with pytest.raises(AssertionError) as excinfo:
+        host.package('sudo').version
+    assert ('The package sudo is not installed, dpkg-query output: '
+            'deinstall ok config-files 1.8.') in str(excinfo.value)
+
+
 @all_images
 def test_systeminfo(host, docker_image):
     assert host.system_info.type == "linux"

--- a/testinfra/modules/package.py
+++ b/testinfra/modules/package.py
@@ -98,10 +98,13 @@ class DebianPackage(Package):
 
     @property
     def version(self):
-        out = self.check_output("dpkg-query -f '${Status} ${Version}' -W %s"
-                                % (self.name,)).split()
-        if out[0].lower() in ["install", "hold"]:
-            return out[3]
+        out = self.check_output("dpkg-query -f '${Status} ${Version}' -W %s",
+                                self.name)
+        splitted = out.split()
+        assert splitted[0].lower() in ('install', 'hold'), (
+            "The package %s is not installed, dpkg-query output: %s" % (
+                self.name, out))
+        return splitted[3]
 
 
 class FreeBSDPackage(Package):


### PR DESCRIPTION
On Debian based systems, dpkg-query might exit with a return code 0 for
uninstalled packages (in case of previously installed packages). In this
case raise an AssertionError instead of returning None

Closes #325