### PR TITLE
fix issue #303

### DIFF
--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -290,6 +290,9 @@ def test_file(host):
     assert l.is_symlink
     assert l.is_file
     assert l.linked_to == "/d/f"
+    assert l.linked_to == f
+    assert f == f
+    assert not d == f
 
     host.check_output("rm -f /d/p && mkfifo /d/p")
     assert host.file("/d/p").is_pipe

--- a/testinfra/modules/file.py
+++ b/testinfra/modules/file.py
@@ -171,6 +171,16 @@ class File(Module):
     def __repr__(self):
         return "<file %s>" % (self.path,)
 
+    def __eq__(self, other):
+        if isinstance(other, File):
+            return self.path == other.path
+        elif isinstance(other, str):
+            return self.path == other
+        return False
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
     @classmethod
     def get_module_class(cls, host):
         if host.system_info.type == "linux":

--- a/testinfra/modules/file.py
+++ b/testinfra/modules/file.py
@@ -14,6 +14,7 @@
 from __future__ import unicode_literals
 
 import datetime
+import six
 
 from testinfra.modules.base import Module
 
@@ -174,7 +175,7 @@ class File(Module):
     def __eq__(self, other):
         if isinstance(other, File):
             return self.path == other.path
-        elif isinstance(other, str):
+        elif isinstance(other, six.string_types):
             return self.path == other
         return False
 


### PR DESCRIPTION
Implements \_\_eq\_\_ and \_\_ne\_\_ methods on the File object.
If both objects are files, the paths are getting compared,
if the other object is a string, it's compared with the path directly.