### PR TITLE
sorted ansible.get_hosts

### DIFF
--- a/testinfra/backend/ansible.py
+++ b/testinfra/backend/ansible.py
@@ -67,4 +67,4 @@ class AnsibleBackend(base.BaseBackend):
     @classmethod
     def get_hosts(cls, host, **kwargs):
         inventory = kwargs.get('ansible_inventory')
-        return AnsibleRunner.get_runner(inventory).get_hosts(host)
+        return sorted(AnsibleRunner.get_runner(inventory).get_hosts(host))


### PR DESCRIPTION
I tested using ansible backend.
The testing host is different from the displayed with "ansible://" host.

As follow
```
$ cat test
[A]
a
c
b
```

```
$ cat test.py
def test_test(host):
    print(host.ansible.get_variables()["inventory_hostname"])
```

```
$ py.test --connect=ansible --ansible-inventory=test -v -s test.py
test.py::test_test[ansible://a] a
PASSED
test.py::test_test[ansible://b] c
PASSED
test.py::test_test[ansible://c] b
PASSED
```

Maybe, it is necessary for the get_hosts method in AnsibleBackend class to be sorted.
Please check on this.