### PR TITLE
Use HTTP with WinRM when user disables SSL

### DIFF
--- a/testinfra/backend/__init__.py
+++ b/testinfra/backend/__init__.py
@@ -48,7 +48,7 @@ def parse_hostspec(hostspec):
         kw["connection"] = url.scheme
         host = url.netloc
         query = urllib.parse.parse_qs(url.query)
-        for key in ('sudo', 'ssl', 'verify_ssl'):
+        for key in ('sudo', 'ssl', 'verify_ssl', 'no_ssl', 'no_verify_ssl'):
             if query.get(key, ['false'])[0].lower() == 'true':
                 kw[key] = True
         for key in ("sudo_user", 'namespace', 'container'):


### PR DESCRIPTION
I've noticed that testinfra always attempts to use HTTPS with the WinRM backend, even when I set the `no_ssl` query parameter. This is causing problems for me because the host in question is not configured to support HTTPS.

It looks like this bug was probably introduced when the `ssl` and `verify_ssl` parameters got inverted--when their names changed, the new names were not added to the 'whitelist' of accepted query parameters on line 51 of `testinfra/backend/__init__.py`.

Adding `no_ssl` and `no_verify_ssl` to the list allows these query parameters to propagate to the WinRMBackend.