### PR TITLE
Add '-w' argument to iptables

### DIFF
--- a/testinfra/modules/iptables.py
+++ b/testinfra/modules/iptables.py
@@ -44,9 +44,9 @@ class Iptables(InstanceModule):
 
         rules = []
         if chain:
-            cmd = "iptables -t {0} -S {1}".format(table, chain)
+            cmd = "iptables -w 90 -t {0} -S {1}".format(table, chain)
         else:
-            cmd = "iptables -t {0} -S".format(table)
+            cmd = "iptables -w 90 -t {0} -S".format(table)
 
         for line in self.check_output(cmd).splitlines():
             line = line.replace("\t", " ")


### PR DESCRIPTION
If multiple tests are executed in parallel (e.g. via pytest-xdist)
and more than one test queries the iptables rules on the same host
simultaneously, the following error will occur:

    E       AssertionError: Unexpected exit code 4 for
    CommandResult(command='iptables -t filter -S', exit_status=4,
    stdout='', stderr='Another app is currently holding the xtables
    lock. Perhaps you want to use the -w option?')

Iptables has an internal lock to prevent multiple simultaneous
invocations.  This change implements that suggestion and adds "-w 90"
to the iptables command so that we will wait up to 90 seconds to
obtain the lock.