### PR TITLE
Fix iptables doc example

### DIFF
--- a/testinfra/modules/iptables.py
+++ b/testinfra/modules/iptables.py
@@ -37,7 +37,7 @@ class Iptables(InstanceModule):
             '-A INPUT -j REJECT'
             '-A FORWARD -j REJECT'
         ]
-        >>> host.iptables().get_rules("nat", "INPUT")
+        >>> host.iptables.rules("nat", "INPUT")
         ['-P PREROUTING ACCEPT']
 
         """


### PR DESCRIPTION
host.iptables().get_rules('table', 'CHAIN') is wrong and it should be host.iptables.rules('table', 'CHAIN')