### PR TITLE
Add ip6tables support to iptables module

### DIFF
--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -469,3 +469,11 @@ def test_iptables(host):
     assert ssh_rule_str in input_rules
     assert vip_redirect_rule_str in nat_rules
     assert vip_redirect_rule_str in nat_prerouting_rules
+    # test ip6tables call works; ipv6 setup is a whole huge thing, but
+    # ensure we at least see the headings
+    v6_rules = host.iptables.rules(version=6)
+    assert '-P INPUT ACCEPT' in v6_rules
+    assert '-P FORWARD ACCEPT' in v6_rules
+    assert '-P OUTPUT ACCEPT' in v6_rules
+    v6_filter_rules = host.iptables.rules('filter', 'INPUT', version=6)
+    assert '-P INPUT ACCEPT' in v6_filter_rules

--- a/testinfra/modules/iptables.py
+++ b/testinfra/modules/iptables.py
@@ -19,7 +19,7 @@ from testinfra.modules.base import InstanceModule
 class Iptables(InstanceModule):
     """Test iptables rule exists"""
 
-    def rules(self, table='filter', chain=None):
+    def rules(self, table='filter', chain=None, version=4):
         """Returns list of iptables rules
 
            Based on ouput of `iptables -t TABLE -S CHAIN` command
@@ -27,6 +27,7 @@ class Iptables(InstanceModule):
              optionally takes takes the following arguments:
                - table: defaults to `filter`
                - chain: defaults to all chains
+               - version: default 4 (iptables), optionally 6 (ip6tables)
 
         >>> host.iptables.rules()
         [
@@ -42,11 +43,18 @@ class Iptables(InstanceModule):
 
         """
 
+        if version == 4:
+            iptables = "iptables"
+        elif version == 6:
+            iptables = "ip6tables"
+        else:
+            raise RuntimeError("Invalid version: %s" % version)
+
         rules = []
         if chain:
-            cmd = "iptables -t {0} -S {1}".format(table, chain)
+            cmd = "{0} -t {1} -S {2}".format(iptables, table, chain)
         else:
-            cmd = "iptables -t {0} -S".format(table)
+            cmd = "{0} -t {1} -S".format(iptables, table)
 
         for line in self.check_output(cmd).splitlines():
             line = line.replace("\t", " ")


### PR DESCRIPTION
Add basic ip6tables support to iptables module.  Adds a "version"
argument to the existing module which switches it to use the ip6tables
binary.