### PR TITLE
Improve CommandResult interface

### DIFF
--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -446,6 +446,11 @@ def test_sudo_to_root(host):
     assert host.user().name == "user"
 
 
+def test_command_execution(host):
+    assert host.run("false").failed
+    assert host.run("true").succeeded
+
+
 def test_pip_package(host):
     assert host.pip_package.get_packages()['pip']['version'] == '9.0.1'
     pytest = host.pip_package.get_packages(pip_path='/v/bin/pip')['pytest']

--- a/testinfra/backend/base.py
+++ b/testinfra/backend/base.py
@@ -45,7 +45,33 @@ class CommandResult(object):
         super(CommandResult, self).__init__()
 
     @property
+    def succeeded(self):
+        """
+        Returns whether the command was successful
+
+        >>> host.run("true").succeeded
+        True
+        """
+        return self.exit_status == 0
+
+    @property
+    def failed(self):
+        """
+        Returns whether the command failed
+
+        >>> host.run("false").failed
+        True
+        """
+        return self.exit_status != 0
+
+    @property
     def rc(self):
+        """
+        Gets the returncode of a command
+
+        >>> host.run("true").rc
+        0
+        """
         return self.exit_status
 
     @property

--- a/testinfra/backend/base.py
+++ b/testinfra/backend/base.py
@@ -46,8 +46,7 @@ class CommandResult(object):
 
     @property
     def succeeded(self):
-        """
-        Returns whether the command was successful
+        """Returns whether the command was successful
 
         >>> host.run("true").succeeded
         True
@@ -56,8 +55,7 @@ class CommandResult(object):
 
     @property
     def failed(self):
-        """
-        Returns whether the command failed
+        """Returns whether the command failed
 
         >>> host.run("false").failed
         True
@@ -66,8 +64,7 @@ class CommandResult(object):
 
     @property
     def rc(self):
-        """
-        Gets the returncode of a command
+        """Gets the returncode of a command
 
         >>> host.run("true").rc
         0


### PR DESCRIPTION
Add a simple `succeeded/failed` interface which allows for simpler assertion in tests.
It is more readable to have tests like:

```python
assert host.run("false").failed
# or
assert host.run("true").succeeded
```
Instead of:

```python
assert host.run("false").rc != 0
# or
assert host.run("true").rc == 0
```