### PR TITLE
add support for setting 'become' when running Ansible module

### DIFF
--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -358,6 +358,23 @@ def test_ansible_module(host):
     assert result['stdout'] == 'foo'
 
 
+@pytest.mark.testinfra_hosts("ansible://debian_stretch",
+                             "ansible://user@debian_stretch")
+def test_ansible_module_become(host):
+    user_name = host.user().name
+    assert host.ansible('shell', 'echo $USER',
+                        check=False)['stdout'] == user_name
+    assert host.ansible('shell', 'echo $USER',
+                        check=False, become=True)['stdout'] == 'root'
+
+    with host.sudo():
+        assert host.user().name == 'root'
+        assert host.ansible('shell', 'echo $USER',
+                            check=False)['stdout'] == user_name
+        assert host.ansible('shell', 'echo $USER',
+                            check=False, become=True)['stdout'] == 'root'
+
+
 @pytest.mark.destructive
 def test_supervisor(host):
     # Wait supervisord is running

--- a/testinfra/modules/ansible.py
+++ b/testinfra/modules/ansible.py
@@ -60,7 +60,13 @@ class Ansible(InstanceModule):
     <https://docs.ansible.com/ansible/playbooks_checkmode.html>`_ is
     enabled by default, you can disable it with `check=False`.
 
+    `Become
+    <https://docs.ansible.com/ansible/user_guide/become.html#id1>`_ is
+    `False` by default. You can enable it with `become=True`.
+
     >>> host.ansible("apt", "name=nginx state=present")["changed"]
+    False
+    >>> host.ansible("apt", "name=nginx state=present", become=True)["changed"]
     False
     >>> host.ansible("command", "echo foo", check=False)["stdout"]
     'foo'
@@ -73,9 +79,10 @@ class Ansible(InstanceModule):
     AnsibleException = AnsibleException
 
     @need_ansible
-    def __call__(self, module_name, module_args=None, check=True, **kwargs):
+    def __call__(self, module_name, module_args=None, check=True,
+                 become=False, **kwargs):
         result = self._host.backend.run_ansible(
-            module_name, module_args, check=check, **kwargs)
+            module_name, module_args, check=check, become=become, **kwargs)
         if result.get("failed", False) is True:
             raise AnsibleException(result)
         return result

--- a/testinfra/utils/ansible_runner.py
+++ b/testinfra/utils/ansible_runner.py
@@ -198,6 +198,7 @@ class AnsibleRunnerV2(AnsibleRunnerBase):
 
     def run(self, host, module_name, module_args=None, **kwargs):
         self.cli.options.check = kwargs.get("check", False)
+        self.cli.options.become = kwargs.get("become", False)
         action = {"module": module_name}
         if module_args is not None:
             if module_name in ("command", "shell"):


### PR DESCRIPTION

Adds support for setting `become` when running an Ansible module:

```py
host.ansible('service', 'name=docker-compose state=restarted', check=False, become=True)
```

The  `sudo()` context manger does not work for Ansible modules; calls to `host.ansible()` are passed to `AnsibleRunner.run()` without going through `get_command` (which is what [`sudo()` monkey patches `get_sudo_command`](https://github.com/philpep/testinfra/blob/master/testinfra/modules/sudo.py#L48) in as). See `test_ansible_module_become` test for evidence of this.
