### PR TITLE
Add ability to pass timeouts to the winrm backend

### DIFF
--- a/doc/source/backends.rst
+++ b/doc/source/backends.rst
@@ -112,7 +112,7 @@ The winrm backend uses `pywinrm <https://pypi.python.org/pypi/pywinrm>`_::
 pywinrm's default read and operation timeout can be overridden using query
 arguments ``read_timeout_sec`` and ``operation_timeout_sec``::
 
-    $ py.test --hosts='winrm://vagrant@127.0.0.1:2200?read_timeout_sec=120,operation_timeout_sec=100'
+    $ py.test --hosts='winrm://vagrant@127.0.0.1:2200?read_timeout_sec=120&operation_timeout_sec=100'
 
 LXC
 ~~~

--- a/doc/source/backends.rst
+++ b/doc/source/backends.rst
@@ -109,6 +109,11 @@ The winrm backend uses `pywinrm <https://pypi.python.org/pypi/pywinrm>`_::
     $ py.test --hosts='winrm://Administrator:Password@127.0.0.1'
     $ py.test --hosts='winrm://vagrant@127.0.0.1:2200?no_ssl=true&no_verify_ssl=true'
 
+pywinrm's default read and operation timeout can be overridden using query
+arguments ``read_timeout_sec`` and ``operation_timeout_sec``::
+
+    $ py.test --hosts='winrm://vagrant@127.0.0.1:2200?read_timeout_sec=120,operation_timeout_sec=100'
+
 LXC
 ~~~
 

--- a/testinfra/backend/__init__.py
+++ b/testinfra/backend/__init__.py
@@ -51,7 +51,8 @@ def parse_hostspec(hostspec):
         for key in ('sudo', 'ssl', 'no_ssl', 'no_verify_ssl'):
             if query.get(key, ['false'])[0].lower() == 'true':
                 kw[key] = True
-        for key in ("sudo_user", 'namespace', 'container'):
+        for key in ("sudo_user", 'namespace', 'container', 'read_timeout_sec',
+                    'operation_timeout_sec'):
             if key in query:
                 kw[key] = query.get(key)[0]
         for key in (

--- a/testinfra/backend/winrm.py
+++ b/testinfra/backend/winrm.py
@@ -64,6 +64,7 @@ class WinRMBackend(base.BaseBackend):
     NAME = "winrm"
 
     def __init__(self, hostspec, no_ssl=False, no_verify_ssl=False,
+                 read_timeout_sec=None, operation_timeout_sec=None,
                  *args, **kwargs):
         self.host = self.parse_hostspec(hostspec)
         self.conn_args = {
@@ -77,6 +78,10 @@ class WinRMBackend(base.BaseBackend):
         }
         if no_verify_ssl:
             self.conn_args['server_cert_validation'] = 'ignore'
+        if read_timeout_sec is not None:
+            self.conn_args['read_timeout_sec'] = read_timeout_sec
+        if operation_timeout_sec is not None:
+            self.conn_args['operation_timeout_sec'] = operation_timeout_sec
         super(WinRMBackend, self).__init__(self.host.name, *args, **kwargs)
 
     def run(self, command, *args, **kwargs):


### PR DESCRIPTION

Add ability to pass timeouts to the winrm backend

The default read and operation timeouts in pywinrm are quite
low - 30 and 20 respectively.

Windows machines in common configurations frequently will exceed these
timeouts on initial login.  I'm frequently finding the first of a suite
of tests using the winrm backend against newly built machines would
fail but the rest would succeed.  Increasing the read and operation timeout parameters used by pywinrm fixed the issue.

I'm guessing others have encountered this issue - ansible had an
identical issue filed which is fixed by the same method: ansible/ansible#16873

This change allows specifying these parameters as query parameters
in the host spec.