### PR TITLE
Avoid configuring logging

### DIFF
--- a/testinfra/plugin.py
+++ b/testinfra/plugin.py
@@ -250,7 +250,9 @@ else:
 @pytest.mark.trylast
 def pytest_configure(config):
     if config.option.verbose > 1:
-        logging.basicConfig()
+        root = logging.getLogger()
+        if not root.handlers:
+            root.addHandler(logging.NullHandler())
         logging.getLogger("testinfra").setLevel(logging.DEBUG)
     if config.option.nagios:
         # disable & re-enable terminalreporter to write in a tempfile


### PR DESCRIPTION
Hi,

When an error occurs, testinfra generates a lot of messages. With stderr and logging capture, the messages appears _twice_. This floods the screen of user. So here is a contribution to start the discussion.

The idea is to avoid `basicConfig` which configures output to stderr.

However, not configuring logging can trigger warning if a message does not have a handler. Thus, i added a check and ensure that root logger have at least a NullHandler. Actually, pytest adds a CapLog handler.

This pattern is common in library using logging to avoid requiring logging configuration. Using NullHandler allows app to call basicConfig on its own or any other configuration.

What do you think of this ?

Regards,
Étienne

Note: I executed `tox -e py35 -- -k ansible` locally before opening this PR.

```
  py35: commands succeeded
  congratulations :)
```

Kudo for testinfra, it's very nice !
