### PR TITLE
Unquote host, user and password in host url spec

### DIFF
--- a/test/test_backends.py
+++ b/test/test_backends.py
@@ -108,6 +108,9 @@ def test_docker_encoding(host):
     ('u:P@h', HostSpec('h', None, 'u', 'P')),
     ('u@h', HostSpec('h', None, 'u', None)),
     ('h', HostSpec('h', None, None, None)),
+    ('pr%C3%A9nom@h', HostSpec('h', None, 'prénom', None)),
+    ('pr%C3%A9nom:p%40ss%3Aw0rd@h', HostSpec('h', None, 'prénom',
+                                             'p@ss:w0rd')),
 ])
 def test_parse_hostspec(hostspec, expected):
     assert BaseBackend.parse_hostspec(hostspec) == expected

--- a/testinfra/backend/base.py
+++ b/testinfra/backend/base.py
@@ -217,6 +217,11 @@ class BaseBackend(object):
                 user, password = user.split(':', 1)
         if ':' in name:
             name, port = name.split(':', 1)
+        name = testinfra.utils.urlunquote(name)
+        if user is not None:
+            user = testinfra.utils.urlunquote(user)
+        if password is not None:
+            password = testinfra.utils.urlunquote(password)
         return HostSpec(name, port, user, password)
 
     @staticmethod

--- a/testinfra/utils/__init__.py
+++ b/testinfra/utils/__init__.py
@@ -13,7 +13,11 @@
 
 from __future__ import unicode_literals
 
+import locale
 import re
+
+import six
+from six.moves import urllib
 
 first_cap_re = re.compile('(.)([A-Z][a-z]+)')
 all_cap_re = re.compile('([a-z0-9])([A-Z])')
@@ -41,3 +45,11 @@ class cached_property(object):
             return self
         value = obj.__dict__[self.func.__name__] = self.func(obj)
         return value
+
+
+if six.PY2:
+    def urlunquote(s):
+        encoding = locale.getpreferredencoding()
+        return urllib.parse.unquote(s.encode(encoding)).decode(encoding)
+else:
+    urlunquote = urllib.parse.unquote


### PR DESCRIPTION
When host, user or password contains specials characters in url string,
we expect them to be urlencoded and we should decode them back.

Closes #387