### PR TITLE
add `module.docker.Docker` class to docs

### DIFF
--- a/doc/source/modules.rst
+++ b/doc/source/modules.rst
@@ -109,6 +109,13 @@ Ansible
    :members:
 
 
+Docker
+~~~~~~
+
+.. autoclass:: testinfra.modules.docker.Docker(name)
+   :members:
+
+
 File
 ~~~~
 


### PR DESCRIPTION
Adding Docker `autoclass` to `modules.rst` for the new Docker Module #300 