### PR TITLE
[LOOKING FOR SOMEONE TO TAKEOVER :-] replace ansible base_parser with create_base_parser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ services:
   - docker
 env:
   matrix:
-    - TOXENV=py27,ansible1,py35
+    - TOXENV=py{27,35}-ansible{2,devel},ansible1
     - TOXENV=flake8
     - TOXENV=pylint
     - TOXENV=sphinxdoc

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,11 @@
 [tox]
-envlist=py27,ansible1,py35,flake8,pylint,sphinxdoc,check-manifest
+envlist=py{27,35}-ansible{2,devel},ansible1,flake8,pylint,sphinxdoc,check-manifest
 
 [testenv]
 deps=
     -rtest-requirements.txt
-    ansible>=2.4,<3
+    ansible2: ansible>=2.4,<3
+    ansibledevel: git+https://github.com/ansible/ansible.git
 commands=
     py.test {posargs:-v -n 4 --cov testinfra --cov-report xml --cov-report term test}
 usedevelop=True


### PR DESCRIPTION
As of https://github.com/ansible/ansible/pull/50069 the base_parser
function no longer exists. Use
ansible.arguments.optparse_helpers.create_base_parser
instead.

Fixes: https://github.com/philpep/testinfra/issues/401