### PR TITLE
Switch to ansible-runner

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
 sphinx>=1.3
 alabaster>=0.7.2
 hacking
+ansible-runner>=1.3.2
 .

--- a/images/debian_stretch/Dockerfile
+++ b/images/debian_stretch/Dockerfile
@@ -1,5 +1,7 @@
 FROM debian:stretch
 
+ENV container docker
+
 # ntpd is linked to /bin/false, so the service is not running but is enabled
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \

--- a/setup.py
+++ b/setup.py
@@ -54,5 +54,6 @@ setuptools.setup(
     install_requires=[
         'pytest!=3.0.2',
         'six>=1.4',
+        'backports.tempfile;python_version<"3"'
     ],
 )

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,4 +5,5 @@ paramiko
 tornado<5
 salt
 pywinrm
+ansible>=2.4,<3
 ansible-runner

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,4 +5,4 @@ paramiko
 tornado<5
 salt
 pywinrm
-ansible>=2.4,<3
+ansible-runner

--- a/testinfra/backend/ansible.py
+++ b/testinfra/backend/ansible.py
@@ -19,7 +19,6 @@ import pprint
 
 from testinfra.backend import base
 from testinfra.utils.ansible_runner import AnsibleRunner
-from testinfra.utils.ansible_runner import to_bytes
 
 logger = logging.getLogger("testinfra")
 
@@ -47,9 +46,6 @@ class AnsibleBackend(base.BaseBackend):
             stderr_bytes=None,
             stdout=out["stdout"], stderr=out["stderr"],
         )
-
-    def encode(self, data):
-        return to_bytes(data)
 
     def run_ansible(self, module_name, module_args=None, **kwargs):
         result = self.ansible_runner.run(

--- a/testinfra/modules/ansible.py
+++ b/testinfra/modules/ansible.py
@@ -83,6 +83,13 @@ class Ansible(InstanceModule):
                  become=False, **kwargs):
         result = self._host.backend.run_ansible(
             module_name, module_args, check=check, become=become, **kwargs)
+        if result == {}:
+            # A blank dictionary means everything was skipped; it
+            # didn't fail but nothing was done
+            result = {
+                'failed': True,
+                'msg': 'Skipped. You might want to try check=False'
+            }
         if result.get("failed", False) is True:
             raise AnsibleException(result)
         return result

--- a/testinfra/utils/ansible_runner.py
+++ b/testinfra/utils/ansible_runner.py
@@ -79,7 +79,7 @@ class AnsibleRunnerV2(object):
             cmd.append('--list')
 
         try:
-            so = subprocess.check_output(cmd)
+            so = subprocess.check_output(cmd, universal_newlines=True)
         except subprocess.CalledProcessError as e:
             raise AnsibleInventoryException(e)
 

--- a/testinfra/utils/ansible_runner.py
+++ b/testinfra/utils/ansible_runner.py
@@ -182,4 +182,3 @@ class AnsibleRunner(object):
             return significant_event
 
         return {}
-

--- a/testinfra/utils/ansible_runner.py
+++ b/testinfra/utils/ansible_runner.py
@@ -34,12 +34,7 @@ if six.PY2:
 else:
     import tempfile
 
-__all__ = ['AnsibleRunner', 'to_bytes']
-
-
-def to_bytes(data):
-    '''Why!?!?'''
-    return b'%s' % data
+__all__ = ['AnsibleRunner']
 
 
 class AnsibleInventoryException(Exception):

--- a/testinfra/utils/ansible_runner.py
+++ b/testinfra/utils/ansible_runner.py
@@ -73,28 +73,25 @@ class AnsibleRunnerV2(object):
     def fetch_inventory(self, host=None):
         '''Helper function for ansible-inventory'''
 
-        cmd = 'ansible-inventory -i %s' % self.host_list
+        cmd = [
+            'ansible-inventory',
+            '-i',
+            self.host_list
+        ]
         if host is not None:
-            cmd += ' --host=%s' % host
+            cmd.append('--host=%s' % host)
         else:
-            cmd += ' --list'
+            cmd.append('--list')
 
-        env = os.environ.copy()
-        env['ANSIBLE_NOCOLOR'] = "1"
-        p = subprocess.Popen(
-            cmd,
-            shell=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            env=env
-        )
-        (so, se) = p.communicate()
+        try:
+            so = subprocess.check_output(cmd)
+        except subprocess.CalledProcessError as e:
+            raise AnsibleInventoryException(e)
 
-        if p.returncode != 0:
-            msg = 'ansible-inventory failed: %s' % se
-            raise AnsibleInventoryException(msg)
-
-        inv = json.loads(so)
+        try:
+            inv = json.loads(so)
+        except json.JSONDecodeError as e:
+            raise AnsibleInventoryException(e)
 
         return inv
 

--- a/testinfra/utils/ansible_runner.py
+++ b/testinfra/utils/ansible_runner.py
@@ -18,7 +18,6 @@
 from __future__ import unicode_literals
 from __future__ import absolute_import
 
-import datetime
 import json
 import os
 import shutil
@@ -128,7 +127,7 @@ class AnsibleRunnerV2(object):
         '''Invokes a single module on a single host and returns dict results'''
 
         # runner must have a directory based payload
-        with tempfile.TemporaryDirectory(prefix='ansible-runner.data.') as data_dir:
+        with tempfile.TemporaryDirectory(prefix='runner.data.') as data_dir:
 
             # runner must have an inventory file
             inv_dir = os.path.join(data_dir, 'inventory')

--- a/testinfra/utils/ansible_runner.py
+++ b/testinfra/utils/ansible_runner.py
@@ -22,14 +22,18 @@ import datetime
 import json
 import os
 import shutil
+import six
 import subprocess
-import tempfile
 import yaml
 
 
 # the real ansible-runner
 import ansible_runner
 
+if six.PY2:
+    import backports.tempfile as tempfile
+else:
+    import tempfile
 
 __all__ = ['AnsibleRunner', 'to_bytes']
 

--- a/testinfra/utils/ansible_runner.py
+++ b/testinfra/utils/ansible_runner.py
@@ -21,7 +21,6 @@ from __future__ import absolute_import
 import datetime
 import json
 import os
-import re
 import shutil
 import subprocess
 import tempfile

--- a/testinfra/utils/ansible_runner.py
+++ b/testinfra/utils/ansible_runner.py
@@ -43,7 +43,7 @@ class AnsibleInventoryException(Exception):
         self.message = message
 
 
-class AnsibleRunnerV2(object):
+class AnsibleRunner(object):
 
     # testinfra api
     _runners = {}
@@ -160,7 +160,7 @@ class AnsibleRunnerV2(object):
                     else:
                         runner_kwargs['cmdline'] += ' --%s' % opt
 
-            return AnsibleRunnerV2.call_runner(runner_kwargs, host)
+            return AnsibleRunner.call_runner(runner_kwargs, host)
 
     @staticmethod
     def call_runner(runner_kwargs, host):
@@ -183,5 +183,3 @@ class AnsibleRunnerV2(object):
 
         return {}
 
-
-AnsibleRunner = AnsibleRunnerV2

--- a/testinfra/utils/ansible_runner.py
+++ b/testinfra/utils/ansible_runner.py
@@ -175,14 +175,13 @@ class AnsibleRunnerV2(object):
 
         # a "significant" event is the event that has the task result
         significant_event = None
-        if events:
-            for event in events:
-                # looking for a runnner_on_ok or runner_on_!start
-                if event['event'] == 'runner_on_start':
-                    continue
-                if event['event'].startswith('runner_on'):
-                    significant_event = event.get('event_data', {}).get('res')
-                    break
+        for event in events:
+            # looking for a runnner_on_ok or runner_on_!start
+            if event['event'] == 'runner_on_start':
+                continue
+            if event['event'].startswith('runner_on'):
+                significant_event = event.get('event_data', {}).get('res')
+                break
 
         if significant_event:
             return significant_event

--- a/testinfra/utils/ansible_runner.py
+++ b/testinfra/utils/ansible_runner.py
@@ -124,8 +124,10 @@ class AnsibleRunnerV2(object):
         '''Invokes a single module on a single host and returns dict results'''
 
         # runner must have a directory based payload
-        data_dir = tempfile.mkdtemp(prefix='runner.data.%s.' \
-            % datetime.datetime.now().isoformat().replace(':', '-'))
+        data_dir = tempfile.mkdtemp(
+            prefix='runner.data.%s.' %
+            datetime.datetime.now().isoformat().replace(':', '-')
+        )
         if os.path.exists(data_dir):
             shutil.rmtree(data_dir)
         if not os.path.exists(data_dir):
@@ -154,14 +156,13 @@ class AnsibleRunnerV2(object):
             f.write('---\n')
             f.write(yaml.dump(this_env))
 
-
         # build the kwarg payload ansible-runner requires
         runner_kwargs = {
             'private_data_dir': data_dir,
             'host_pattern': host,
             'module': module_name,
             'module_args': module_args,
-            'json_mode' : True,
+            'json_mode': True,
         }
 
         # ansible-runner does not have kwargs for these


### PR DESCRIPTION
Switch to ansible-runner instead of directly interfacing with ansible

Based on @jctanner gist at
https://gist.github.com/jctanner/512ec07171d95e61a5b7fd5f9103a301

I hope we can collaborate around something like this.  I'm making a common pull request but please update ... our infra can test pull requests from the main repo

Not ready to merge, obviously, but this reliably works for the backend tests (and my local tests) with both local and remote ansible that go via the ```shell``` module.

The two tests that fail are not using ``shell`` output.  As mentioned inline; I can't seem to get the json response from ansible-runner reliably.  I get the feeling ansible-runner is sometimes dropping some of the output of the ansible process in it's ``stdout`` descriptor it returns.  This is a problem for the things *not* calling the ```shell``` module.