### PR TITLE
service: systemd fallback to sysv when systemctl is not working

### DIFF
--- a/testinfra/modules/service.py
+++ b/testinfra/modules/service.py
@@ -103,8 +103,12 @@ class SystemdService(SysvService):
 
     @property
     def is_running(self):
-        return self.run_expect(
-            [0, 3], "systemctl is-active %s", self.name).rc == 0
+        out = self.run_expect(
+            [0, 1, 3], "systemctl is-active %s", self.name)
+        if out.rc == 1:
+            # Failed to connect to bus: No such file or directory
+            return super(SystemdService, self).is_running
+        return out.rc == 0
 
     @property
     def is_enabled(self):


### PR DESCRIPTION
Systemd might not be the pid 1 on docker hosts for instance.
Seems "is-enabled" works but not "is-active", in this case (observed on
ubuntu:xenial) the exit code is 1 with message "Failed to connect to
bus: No such file or directory".

Closes #418