### PR TITLE
Add Windows support

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -10,6 +10,7 @@ disable=
     inconsistent-return-statements,
     keyword-arg-before-vararg,
     useless-object-inheritance,  # to be removed for py3
+    duplicate-code,  # too many false positives between file and user modules :/
     wrong-import-order
 max-branches=20
 max-bool-expr=6

--- a/testinfra/modules/package.py
+++ b/testinfra/modules/package.py
@@ -65,6 +65,8 @@ class Package(Module):
 
     @classmethod
     def get_module_class(cls, host):
+        if host.system_info.type == 'windows':
+            return ChocolateyPackage
         if host.system_info.type == "freebsd":
             return FreeBSDPackage
         if host.system_info.type in ("openbsd", "netbsd"):
@@ -189,6 +191,7 @@ class ArchPackage(Package):
     @property
     def release(self):
         raise NotImplementedError
+
 
 class ChocolateyPackage(Package):
 

--- a/testinfra/modules/package.py
+++ b/testinfra/modules/package.py
@@ -64,7 +64,7 @@ class Package(Module):
         return "<package %s>" % (self.name,)
 
     @classmethod
-    def get_module_class(cls, host):
+    def get_module_class(cls, host): # pylint: disable=too-many-return-statements
         if host.system_info.type == 'windows':
             return ChocolateyPackage
         if host.system_info.type == "freebsd":

--- a/testinfra/modules/package.py
+++ b/testinfra/modules/package.py
@@ -189,3 +189,18 @@ class ArchPackage(Package):
     @property
     def release(self):
         raise NotImplementedError
+
+class ChocolateyPackage(Package):
+
+    @property
+    def is_installed(self):
+        return self.run_test("choco info -lo %s", self.name).rc == 0
+
+    @property
+    def version(self):
+        out = self.check_output("choco info -lo %s -r", self.name).split("|")
+        return out[-1]
+
+    @property
+    def release(self):
+        raise NotImplementedError

--- a/testinfra/modules/package.py
+++ b/testinfra/modules/package.py
@@ -64,7 +64,8 @@ class Package(Module):
         return "<package %s>" % (self.name,)
 
     @classmethod
-    def get_module_class(cls, host): # pylint: disable=too-many-return-statements
+    # pylint: disable=too-many-return-statements
+    def get_module_class(cls, host):
         if host.system_info.type == 'windows':
             return ChocolateyPackage
         if host.system_info.type == "freebsd":
@@ -201,8 +202,9 @@ class ChocolateyPackage(Package):
 
     @property
     def version(self):
-        out = self.check_output("choco info -lo %s -r", self.name).split("|")
-        return out[-1]
+        _, version = self.check_output(
+            "choco info -lo %s -r", self.name).split("|", 1)
+        return version
 
     @property
     def release(self):

--- a/testinfra/modules/systeminfo.py
+++ b/testinfra/modules/systeminfo.py
@@ -30,8 +30,9 @@ class SystemInfo(InstanceModule):
             "codename": None,
             "release": None,
         }
-        uname = self.run_expect([0, 127], 'uname -s')
-        if uname.rc == 127:
+        uname = self.run_expect([0, 1], 'uname -s')
+        if uname.rc == 1:
+            # FIXME: find a better way to detect windows here
             sysinfo.update(**self._get_windows_sysinfo())
             return sysinfo
         sysinfo["type"] = uname.stdout.rstrip("\r\n").lower()

--- a/testinfra/modules/systeminfo.py
+++ b/testinfra/modules/systeminfo.py
@@ -34,7 +34,7 @@ class SystemInfo(InstanceModule):
         if uname.rc == 127:
             sysinfo.update(**self._get_windows_sysinfo())
             return sysinfo
-        sysinfo["type"] = uname.stdout.rstrip("\r\n")
+        sysinfo["type"] = uname.stdout.rstrip("\r\n").lower()
         if sysinfo["type"] == "linux":
             sysinfo.update(**self._get_linux_sysinfo())
         elif sysinfo["type"] == "darwin":

--- a/testinfra/modules/systeminfo.py
+++ b/testinfra/modules/systeminfo.py
@@ -30,7 +30,13 @@ class SystemInfo(InstanceModule):
             "codename": None,
             "release": None,
         }
-        sysinfo["type"] = self.check_output("uname -s").lower()
+
+        try:
+            sysinfo["type"] = self.check_output("uname -s").lower()
+        except AssertionError:
+            sysinfo.update(**self._get_windows_sysinfo())
+            return sysinfo
+
         if sysinfo["type"] == "linux":
             sysinfo.update(**self._get_linux_sysinfo())
         elif sysinfo["type"] == "darwin":
@@ -125,6 +131,7 @@ class SystemInfo(InstanceModule):
                 value = value.strip()
                 if key == "os_name":
                     sysinfo["distribution"] = value
+                    sysinfo["type"] = value.split(" ")[1].lower()
                 elif key == "os_version":
                     sysinfo["release"] = value
 

--- a/testinfra/modules/systeminfo.py
+++ b/testinfra/modules/systeminfo.py
@@ -114,6 +114,22 @@ class SystemInfo(InstanceModule):
 
         return sysinfo
 
+    def _get_windows_sysinfo(self):
+        sysinfo = {}
+
+        sw_vers = self.run("systeminfo | findstr /B /C:\"OS\"")
+        if sw_vers.rc == 0:
+            for line in sw_vers.stdout.splitlines():
+                key, value = line.split(":", 1)
+                key = key.strip().replace(' ', '_').lower()
+                value = value.strip()
+                if key == "os_name":
+                    sysinfo["distribution"] = value
+                elif key == "os_version":
+                    sysinfo["release"] = value
+
+        return sysinfo
+
     @property
     def type(self):
         """OS type

--- a/testinfra/modules/user.py
+++ b/testinfra/modules/user.py
@@ -109,7 +109,7 @@ class User(Module):
     def get_module_class(cls, host):
         if host.system_info.type.endswith("bsd"):
             return BSDUser
-        elif host.system_info.type == 'windows':
+        if host.system_info.type == 'windows':
             return WindowsUser
         return super(User, cls).get_module_class(host)
 

--- a/testinfra/modules/user.py
+++ b/testinfra/modules/user.py
@@ -109,6 +109,8 @@ class User(Module):
     def get_module_class(cls, host):
         if host.system_info.type.endswith("bsd"):
             return BSDUser
+        elif host.system_info.type == 'windows':
+            return WindowsUser
         return super(User, cls).get_module_class(host)
 
     def __repr__(self):
@@ -133,3 +135,68 @@ class BSDUser(User):
         if seconds > 0:
             epoch = datetime.datetime.utcfromtimestamp(0)
             return epoch + datetime.timedelta(seconds=int(seconds))
+
+
+class WindowsUser(User):
+
+    @property
+    def name(self):
+        """Return user name"""
+        if self._name is None:
+            self._name = self.check_output("echo %username%")
+        return self._name
+
+    @property
+    def exists(self):
+        return self.run_test("net user %s", self.name).rc == 0
+
+    @property
+    def uid(self):
+        raise NotImplementedError
+
+    @property
+    def gid(self):
+        raise NotImplementedError
+
+    @property
+    def group(self):
+        raise NotImplementedError
+
+    @property
+    def gids(self):
+        raise NotImplementedError
+
+    @property
+    def groups(self):
+        """Return the list of user local group names"""
+        local_groups = self.check_output("net user %s | findstr /B /C:\"Local "
+                                         "Group Memberships\"", self.name)
+        local_groups = local_groups.split()[3:]
+        return [g.replace('*', '') for g in local_groups]
+
+    @property
+    def home(self):
+        raise NotImplementedError
+
+    @property
+    def shell(self):
+        raise NotImplementedError
+
+    @property
+    def gecos(self):
+        comment = self.check_output("net user %s | find /B /C:\"Comment\"",
+                                    self.name)
+        return comment.split().strip()[1]
+
+    @property
+    def password(self):
+        raise NotImplementedError
+
+    @property
+    def expiration_date(self):
+        expiration = self.check_output("net user %s | findstr /B /C:\"Password \
+                                       expires\"", self.name)
+        expiration = expiration.split().strip()[1]
+        if expiration == 'Never':
+            return None
+        return datetime.datetime.strptime(expiration, '%m/%d/%Y %H:%M%S %p')


### PR DESCRIPTION
This adds some basic support for Windows packages (chocolatey) and users. I'm not sure how to add tests for this because the Windows docker images that are available require a Windows host to run.  Also, I apologize for this in advance. We needed to be able to test some things at work, so I thought I'd see if I could add some very basic Windows support. This helps to start addressing #330, but I haven't yet worked out a solution for the file module.