### PR TITLE
Enable is_running test for archlinux

### DIFF
--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -117,8 +117,7 @@ def test_ssh_service(host, docker_image):
     ssh = host.service(name)
     if docker_image == "ubuntu_xenial":
         assert not ssh.is_running
-    # FIXME: is_running test is broken for archlinux for unknown reason
-    elif docker_image != "archlinux":
+    else:
         assert ssh.is_running
 
     if docker_image == "ubuntu_xenial":


### PR DESCRIPTION
Hello,

I've faced the error you mention about broken "is_running" test under Archlinux.
It was only because systemd was trying to mount an absent device before launching sshd which was effectively not running at the moment of the test.

Once I've fixed this issue on my container by masking the device mount, sshd has been able to start at container startup and test ran fine. 

So basically, code is fine, container may be not (problem was coming from my kernel cmdline).