### PR TITLE
Switch from ansible python api to ansible-runner

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
 sphinx>=1.3
 alabaster>=0.7.2
 hacking
+ansible-runner>=1.3.2
 .

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,4 +5,4 @@ paramiko
 tornado<5
 salt
 pywinrm
-ansible>=2.4,<3
+ansible-runner

--- a/testinfra/backend/ansible.py
+++ b/testinfra/backend/ansible.py
@@ -19,7 +19,6 @@ import pprint
 
 from testinfra.backend import base
 from testinfra.utils.ansible_runner import AnsibleRunner
-from testinfra.utils.ansible_runner import to_bytes
 
 logger = logging.getLogger("testinfra")
 
@@ -47,9 +46,6 @@ class AnsibleBackend(base.BaseBackend):
             stderr_bytes=None,
             stdout=out["stdout"], stderr=out["stderr"],
         )
-
-    def encode(self, data):
-        return to_bytes(data)
 
     def run_ansible(self, module_name, module_args=None, **kwargs):
         result = self.ansible_runner.run(

--- a/testinfra/utils/ansible_runner.py
+++ b/testinfra/utils/ansible_runner.py
@@ -30,12 +30,7 @@ import yaml
 import ansible_runner
 
 
-__all__ = ['AnsibleRunner', 'to_bytes']
-
-
-def to_bytes(data):
-    '''Why!?!?'''
-    return b'%s' % data
+__all__ = ['AnsibleRunner']
 
 
 class AnsibleInventoryException(Exception):

--- a/testinfra/utils/ansible_runner.py
+++ b/testinfra/utils/ansible_runner.py
@@ -18,7 +18,6 @@
 from __future__ import unicode_literals
 from __future__ import absolute_import
 
-import datetime
 import json
 import os
 import shutil
@@ -124,7 +123,7 @@ class AnsibleRunnerV2(object):
         '''Invokes a single module on a single host and returns dict results'''
 
         # runner must have a directory based payload
-        with tempfile.TemporaryDirectory(prefix='ansible-runner.data.') as data_dir:
+        with tempfile.TemporaryDirectory(prefix='runner.data.') as data_dir:
 
             # runner must have an inventory file
             inv_dir = os.path.join(data_dir, 'inventory')

--- a/testinfra/utils/ansible_runner.py
+++ b/testinfra/utils/ansible_runner.py
@@ -171,14 +171,13 @@ class AnsibleRunnerV2(object):
 
         # a "significant" event is the event that has the task result
         significant_event = None
-        if events:
-            for event in events:
-                # looking for a runnner_on_ok or runner_on_!start
-                if event['event'] == 'runner_on_start':
-                    continue
-                if event['event'].startswith('runner_on'):
-                    significant_event = event.get('event_data', {}).get('res')
-                    break
+        for event in events:
+            # looking for a runnner_on_ok or runner_on_!start
+            if event['event'] == 'runner_on_start':
+                continue
+            if event['event'].startswith('runner_on'):
+                significant_event = event.get('event_data', {}).get('res')
+                break
 
         if significant_event:
             return significant_event

--- a/testinfra/utils/ansible_runner.py
+++ b/testinfra/utils/ansible_runner.py
@@ -21,7 +21,6 @@ from __future__ import absolute_import
 import datetime
 import json
 import os
-import re
 import shutil
 import subprocess
 import tempfile

--- a/testinfra/utils/ansible_runner.py
+++ b/testinfra/utils/ansible_runner.py
@@ -124,8 +124,10 @@ class AnsibleRunnerV2(object):
         '''Invokes a single module on a single host and returns dict results'''
 
         # runner must have a directory based payload
-        data_dir = tempfile.mkdtemp(prefix='runner.data.%s.' \
-            % datetime.datetime.now().isoformat().replace(':', '-'))
+        data_dir = tempfile.mkdtemp(
+            prefix='runner.data.%s.' %
+            datetime.datetime.now().isoformat().replace(':', '-')
+        )
         if os.path.exists(data_dir):
             shutil.rmtree(data_dir)
         if not os.path.exists(data_dir):
@@ -154,14 +156,13 @@ class AnsibleRunnerV2(object):
             f.write('---\n')
             f.write(yaml.dump(this_env))
 
-
         # build the kwarg payload ansible-runner requires
         runner_kwargs = {
             'private_data_dir': data_dir,
             'host_pattern': host,
             'module': module_name,
             'module_args': module_args,
-            'json_mode' : True,
+            'json_mode': True,
         }
 
         # ansible-runner does not have kwargs for these


### PR DESCRIPTION
Supercedes https://github.com/philpep/testinfra/pull/410

fixes https://github.com/philpep/testinfra/issues/401
fixes https://github.com/ansible/molecule/issues/1727

There's a couple reasons for this pullrequest ...

1. The ansible python api is unstable, and upkeep for testinfra will continue to be a pain point.
2. ansible-runner is how Ansible Tower and AWX communicate with ansible and will be perpetually maintained
3. testinfra is Apache licensed and imports ansible which is GPL licensed. This violates GPL for most people's interpretation of GPL https://opensource.stackexchange.com/a/1641

NOTE: Molecule can not yet use this version until an incompatibility with colorama is fixed https://github.com/ansible/molecule/pull/2001