### PR TITLE
Add container env to debian Stretch Dockerfile

### DIFF
--- a/images/debian_stretch/Dockerfile
+++ b/images/debian_stretch/Dockerfile
@@ -1,5 +1,7 @@
 FROM debian:stretch
 
+ENV container docker
+
 # ntpd is linked to /bin/false, so the service is not running but is enabled
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \


### PR DESCRIPTION
systemd requires the "container" variable be set when it is running
inside a container [1].  Without this, on some hosts the container can
go into a silent purgatory enforced by selinux where systemd is
running, but sshd or other services never start in the container
... leading to ansible tests simply hanging forever trying to ssh in.

[1] https://www.freedesktop.org/wiki/Software/systemd/ContainerInterface/