### PR TITLE
Handle literal ipv6 addresses

### DIFF
--- a/test/test_backends.py
+++ b/test/test_backends.py
@@ -233,6 +233,14 @@ def test_docker_encoding(host):
     ('pr%C3%A9nom@h', HostSpec('h', None, 'prénom', None)),
     ('pr%C3%A9nom:p%40ss%3Aw0rd@h', HostSpec('h', None, 'prénom',
                                              'p@ss:w0rd')),
+    # ipv6 matching
+    ('[2001:db8:a0b:12f0::1]',
+     HostSpec('2001:db8:a0b:12f0::1', None, None, None)),
+    ('user:password@[2001:db8:a0b:12f0::1]',
+     HostSpec('2001:db8:a0b:12f0::1', None, 'user', 'password')),
+    ('user:password@[2001:4800:7819:103:be76:4eff:fe04:9229]:22',
+     HostSpec('2001:4800:7819:103:be76:4eff:fe04:9229', '22',
+              'user', 'password')),
 ])
 def test_parse_hostspec(hostspec, expected):
     assert BaseBackend.parse_hostspec(hostspec) == expected

--- a/testinfra/backend/base.py
+++ b/testinfra/backend/base.py
@@ -214,8 +214,21 @@ class BaseBackend(object):
             user, name = name.split('@', 1)
             if ':' in user:
                 user, password = user.split(':', 1)
-        if ':' in name:
-            name, port = name.split(':', 1)
+        # A literal IPv6 address might be like
+        #  [fe80:0::a:b:c]:80
+        # thus, below in words; if this starts with a '[' assume it
+        # encloses an ipv6 address with a closing ']', with a possible
+        # trailing port after a colon
+        if name.startswith('['):
+            name, port = name.split(']')
+            name = name[1:]
+            if port.startswith(':'):
+                port = port[1:]
+            else:
+                port = None
+        else:
+            if ':' in name:
+                name, port = name.split(':', 1)
         name = testinfra.utils.urlunquote(name)
         if user is not None:
             user = testinfra.utils.urlunquote(user)

--- a/testinfra/utils/__init__.py
+++ b/testinfra/utils/__init__.py
@@ -44,6 +44,41 @@ class cached_property(object):
         value = obj.__dict__[self.func.__name__] = self.func(obj)
         return value
 
+if six.PY2:
+    import socket
+
+    # An approximation of ipaddress function
+    def check_ip_address(value):
+        '''check_ip_address
+
+        Look at value and see if it looks like a plain ip address
+
+        Returns:
+
+          4 : ipv4 address
+          6 : ipv6 address
+          None: not an ip address
+        '''
+        try:
+            socket.inet_aton(value)
+            return 4
+        except socket.error:
+            pass
+        try:
+            socket.inet_pton(socket.AF_INET6, value)
+            return 6
+        except socket.error:
+            pass
+        return None
+
+else:
+    import ipaddress
+
+    def check_ip_address(value):
+        try:
+            return ipaddress.ip_address(value).version
+        except ValueError:
+            return None
 
 if six.PY2:
     def urlunquote(s):

--- a/testinfra/utils/ansible_runner.py
+++ b/testinfra/utils/ansible_runner.py
@@ -22,6 +22,7 @@ from six.moves import configparser
 
 import testinfra
 from testinfra.utils import cached_property
+from testinfra.utils import check_ip_address
 from testinfra.utils import TemporaryDirectory
 
 
@@ -91,7 +92,10 @@ def get_ansible_host(config, inventory, host):
     spec = '{}://'.format(connection)
     if user:
         spec += '{}@'.format(user)
-    spec += testinfra_host
+    if check_ip_address(testinfra_host) == 6:
+        spec += '[' + testinfra_host + ']'
+    else:
+        spec += testinfra_host
     if port:
         spec += ':{}'.format(port)
     return testinfra.get_host(spec, **kwargs)


### PR DESCRIPTION
An ansible inventory might specify the "ansible_host" as a literal
ipv6 address.

This needs handling in ingestion; in ansible_runner.py we add a check
if the host looks like a literal ipv6 address and enclose it in []'s
per RFC2732 (a util function is added for this, which works better on
Python 3).

When connecting, testinfra's host parsing in backend/base.py then
needs to check for []'s in the connection string and extract the
literal ipv6 address if found.  The test-case for this is updated with
a few ipv6 examples.