### PR TITLE
ansible: fix when host list is not specified

### DIFF
--- a/test/test_backends.py
+++ b/test/test_backends.py
@@ -17,6 +17,7 @@ import os
 import pytest
 import tempfile
 
+import testinfra
 import testinfra.backend
 from testinfra.backend.base import BaseBackend
 from testinfra.backend.base import HostSpec
@@ -173,6 +174,16 @@ def test_ansible_get_host(inventory, expected):
         backend = AnsibleRunner(f.name).get_host('host').backend
         for attr, value in expected.items():
             assert operator.attrgetter(attr)(backend) == value
+
+
+def test_ansible_no_host():
+    with tempfile.NamedTemporaryFile() as f:
+        f.write(b'host\n')
+        f.flush()
+        assert AnsibleRunner(f.name).get_hosts() == ['host']
+        hosts = testinfra.get_hosts(
+            [None], connection='ansible', ansible_inventory=f.name)
+        assert [h.backend.get_pytest_id() for h in hosts] == ['ansible://host']
 
 
 def test_ansible_unhandled_connection():

--- a/testinfra/backend/ansible.py
+++ b/testinfra/backend/ansible.py
@@ -56,4 +56,4 @@ class AnsibleBackend(base.BaseBackend):
     @classmethod
     def get_hosts(cls, host, **kwargs):
         inventory = kwargs.get('ansible_inventory')
-        return AnsibleRunner.get_runner(inventory).get_hosts(host)
+        return AnsibleRunner.get_runner(inventory).get_hosts(host or "all")

--- a/testinfra/utils/ansible_runner.py
+++ b/testinfra/utils/ansible_runner.py
@@ -105,7 +105,7 @@ class AnsibleRunner(object):
         self._host_cache = {}
         super(AnsibleRunner, self).__init__()
 
-    def get_hosts(self, pattern=None):
+    def get_hosts(self, pattern="all"):
         inventory = self.inventory
         result = set()
 


### PR DESCRIPTION
When host list is not specified we should parametrize "all" ansible hosts.

Closes #437