### PR TITLE
ansible: add "groups" key to get_variables()

### DIFF
--- a/test/test_backends.py
+++ b/test/test_backends.py
@@ -121,18 +121,25 @@ def test_ansible_get_variables():
 
         def get_vars(host):
             return AnsibleRunner(f.name).get_variables(host)
+        groups = {
+            'all': ['centos', 'debian'],
+            'g': ['debian'],
+            'ungrouped': ['centos'],
+        }
         assert get_vars("debian") == {
             'a': 'b',
             'c': 'd',
             'x': 'z',
             'inventory_hostname': 'debian',
             'group_names': ['g'],
+            'groups': groups,
         }
         assert get_vars("centos") == {
             'a': 'a',
             'e': 'f',
             'inventory_hostname': 'centos',
             'group_names': ['ungrouped'],
+            'groups': groups,
         }
 
 

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -338,6 +338,11 @@ def test_ansible_module(host):
     assert variables["mygroupvar"] == "qux"
     assert variables["inventory_hostname"] == "debian_stretch"
     assert variables["group_names"] == ["testgroup"]
+    assert variables["groups"] == {
+        "all": ["debian_stretch"],
+        "testgroup": ["debian_stretch"],
+        "ungrouped": [],
+    }
 
     with pytest.raises(host.ansible.AnsibleException) as excinfo:
         host.ansible("command", "zzz")

--- a/testinfra/utils/ansible_runner.py
+++ b/testinfra/utils/ansible_runner.py
@@ -142,16 +142,21 @@ class AnsibleRunner(object):
 
     def get_variables(self, host):
         inventory = self.inventory
+        # inventory_hostname, group_names and groups are for backward
+        # compatibility with testinfra 2.X
         hostvars = inventory['_meta'].get(
             'hostvars', {}).get(host, {})
         hostvars.setdefault('inventory_hostname', host)
-        groups = []
+        group_names = []
+        groups = {}
         for group in sorted(inventory):
-            if group in ('_meta', 'all'):
+            if group == "_meta":
                 continue
-            if host in inventory[group].get('hosts', []):
-                groups.append(group)
-        hostvars.setdefault('group_names', groups)
+            groups[group] = sorted(list(itergroup(inventory, group)))
+            if group != "all" and host in inventory[group].get('hosts', []):
+                group_names.append(group)
+        hostvars.setdefault('group_names', group_names)
+        hostvars.setdefault('groups', groups)
         return hostvars
 
     def get_host(self, host, **kwargs):


### PR DESCRIPTION
This key was returned by ansible python API in testinfra 2.X and users
rely on it.

Closes #443