### PR TITLE
Support `ansible_private_key_file` as well

### DIFF
--- a/test/test_backends.py
+++ b/test/test_backends.py
@@ -161,6 +161,14 @@ def test_ansible_get_variables():
         'host.port': '2222',
         'ssh_identity_file': 'key',
     }),
+    ('host', {}, b'host ansible_host=127.0.1.1 ansible_user=u ansible_private_key_file=key ansible_port=2222 ansible_become=yes ansible_become_user=u', {  # noqa
+        'NAME': 'paramiko',
+        'sudo': True,
+        'sudo_user': 'u',
+        'host.name': '127.0.1.1',
+        'host.port': '2222',
+        'ssh_identity_file': 'key',
+    }),
     ('host', {}, b'host ansible_connection=docker', {
         'NAME': 'docker',
         'name': 'host',

--- a/testinfra/utils/ansible_runner.py
+++ b/testinfra/utils/ansible_runner.py
@@ -82,9 +82,15 @@ def get_ansible_host(config, inventory, host, ssh_config=None,
         kwargs['ssh_config'] = ssh_config
     if ssh_identity_file is not None:
         kwargs['ssh_identity_file'] = ssh_identity_file
+
+    # Support both keys as advertised by Ansible
     if 'ansible_ssh_private_key_file' in hostvars:
         kwargs['ssh_identity_file'] = hostvars[
             'ansible_ssh_private_key_file']
+    elif 'ansible_private_key_file' in hostvars:
+        kwargs['ssh_identity_file'] = hostvars[
+            'ansible_private_key_file']
+
     spec = '{}://'.format(connection)
     if user:
         spec += '{}@'.format(user)


### PR DESCRIPTION
Hi there, we received a report on https://github.com/ansible/molecule/issues/2069 about Molecule failing to make an SSH connection and after a quick glance over in https://github.com/ansible/molecule/issues/2069#issuecomment-496456638, I think I have a patch.

The short of it is, Ansible advertises that you can use both "ansible_ssh_private_key_file" and "ansible_private_key_file" for specifying SSH connection options and Molecule happens to use the "ansible_private_key_file" by default. The new Ansible runner implementation here in Testinfra (from what I can tell) does not pick this up.

Didn't dig too deeply on this but hopefully this goes in the right direction ...