### PR TITLE
Add extras for backend dependencies

### DIFF
--- a/doc/source/backends.rst
+++ b/doc/source/backends.rst
@@ -1,7 +1,14 @@
 Connection backends
 ===================
 
-Testinfra comes with several connections backends for remote command execution.
+Testinfra comes with several connections backends for remote command
+execution.
+
+When installing, you should select the backends you require as
+``extras`` to ensure Python dependencies are satisifed (note various
+system packaged tools may still be required).  For example ::
+
+    $ pip install testinfra[ansible,salt]
 
 For all backends, commands can be run as superuser with the ``--sudo``
 option or as specific user with the ``--sudo-user`` option.

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,14 @@ universal = 1
 
 [tool:pytest]
 norecursedirs = .tox .git .local *.egg build
+
+[options.extras_require]
+ansible = ansible>=2.8,<3; paramiko
+docker =
+kubectl =
+local =
+lxc =
+paramiko = paramiko
+salt = salt; tornado
+winrm = pywinrm
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,12 +5,11 @@ universal = 1
 norecursedirs = .tox .git .local *.egg build
 
 [options.extras_require]
-ansible = ansible>=2.8,<3; paramiko
+ansible = ansible
 docker =
 kubectl =
 local =
 lxc =
 paramiko = paramiko
-salt = salt; tornado
+salt = salt
 winrm = pywinrm
-


### PR DESCRIPTION
This adds environment selectors for backends in setup.cfg.  The
inspiration here is that the ansible backend actually requires
paramiko but it isn't specified anywhere.  Having environment markers
makes it a bit eaiser in CI environments to ensure everything is
present.

I've taken a guess at the requirements for the others; although
they're simple I think it's good for consistency to have all backends
with their own environment.  A documentation note is added too.