### PR TITLE
pass kwargs to ansible

### DIFF
--- a/testinfra/utils/ansible_runner.py
+++ b/testinfra/utils/ansible_runner.py
@@ -193,6 +193,9 @@ class AnsibleRunner(object):
             cmd += ' --become'
         if check:
             cmd += ' --check'
+        if kwargs:
+            for kwarg in kwargs.values():
+                cmd += ' ' + kwarg
         cmd += ' %s'
         args += [host]
         with TemporaryDirectory() as d:


### PR DESCRIPTION
**Abstract**

The keyword arguments in `def run_module(self, host, module_name, module_args, become=False, check=True, **kwargs)` in *testinfra/utils/ansible_runner.py* are currently unused. This pull request passes them on to ansible.

**Benefit**

Passing arbitrary arguments to ansible would among other things allow to pass extra variables to ansible. I've only used the values (not the keys) as it is more api stable and because the ansible command line tool uses short and long options.

**Example**

With this pull request we can use the [ansible debug module](https://docs.ansible.com/ansible/latest/modules/debug_module.html) to resolve any jnja2 template. This includes templates containing lookup plugins as the [ansible lookup plugin](https://docs.ansible.com/ansible/latest/plugins/lookup/passwordstore.html). So we can include secrets (e.g. third-party passwords needed for system tests) in testinfra without exposing them in our molecule scenarios.

**Motivation**

I am currently working on a helper python module for testinfra and molecule. It provides a testvars fixture which itself uses the testinfra host fixture. The testvars fixture **resolves** and **exposes** variables provided by roles and testinfra.

It reads variables from yaml files into a python dictionary respecting the [ansible variable precedence](https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html#variable-precedence-where-should-i-put-a-variable). It then updates the role vars with `host.ansible.get_variables()`.

Now the testvars are converted to json file which is the result type of the ansible debug module and which is accepted as input format by ansible. In fact, json is the [recommended input format](https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html#passing-variables-on-the-command-line) of `--extra-vars`: 
> Use the JSON format if you need to pass in anything that shouldn’t be a string

It then uses the json testvars in two different ways.

1. It uses [re.sub](https://docs.python.org/3/library/re.html#re.sub) and an anonymous [lambda function](https://docs.python.org/3/tutorial/controlflow.html#lambda-expressions) to search and replace jinja2 templates in the testvars:
```
regex_templates = r'{{.*?}}'
testvars_json = \
    re.sub(regex_templates,
    lambda match: _resolve_template_(match.group(0)),
    testvars_unresolved_json,
    flags=re.S)

# load json and unescape characters
testvars = json.loads(testvars_json)
```
2. It stores the testvars in a json file in an ephemeral directory provided by molecule. In `_resolve_template_` this file is used as an input to the ansible debug module which then resolves the jinja2 templates:
```
kwargs = {'extravars': '--extra-vars=@' + testvars_dumpfilename}
template_resolved = str(host.ansible('debug', 'msg=' + template_unresolved, **kwargs)['msg'])

# escape resolved template
template_resolved = json.dumps(template_resolved).strip('"')
```