### PR TITLE
DEBUG log when running commands

### DIFF
--- a/testinfra/backend/base.py
+++ b/testinfra/backend/base.py
@@ -278,5 +278,5 @@ class BaseBackend(object):
 
     def result(self, *args, **kwargs):
         result = CommandResult(self, *args, **kwargs)
-        logger.info("RUN %s", result)
+        logger.debug("RUN %s", result)
         return result


### PR DESCRIPTION
For those using Ansible inventories and who want to log in their `pytest`'s with `INFO` logging, this currently will log sensitive vault variables. It'd be preferable if this was just a `DEBUG` log instead.

This is the only `INFO` log I encounter in `testinfra` when using an `ansible` connection so hopefully this won't upset anyone. Thanks for a great plugin!