### PR TITLE
Allow to use password from inventory using paramiko and ssh backends

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ flake8.report
 junit*.xml
 doc/build
 .cache
+.kdev4/
+testinfra.kdev4

--- a/testinfra/backend/paramiko.py
+++ b/testinfra/backend/paramiko.py
@@ -77,6 +77,7 @@ class ParamikoBackend(base.BaseBackend):
             "hostname": self.host.name,
             "port": int(self.host.port) if self.host.port else 22,
             "username": self.host.user,
+            "password": self.host.password,
             "timeout": self.timeout,
         }
         if self.ssh_config:

--- a/testinfra/backend/ssh.py
+++ b/testinfra/backend/ssh.py
@@ -36,6 +36,9 @@ class SshBackend(base.BaseBackend):
     def run_ssh(self, command):
         cmd = ["ssh"]
         cmd_args = []
+        if self.host.password:
+            cmd = ["sshpass"]
+            cmd_args = ["-p", self.host.password, "ssh"]
         if self.ssh_config:
             cmd.append("-F %s")
             cmd_args.append(self.ssh_config)

--- a/testinfra/utils/ansible_runner.py
+++ b/testinfra/utils/ansible_runner.py
@@ -74,6 +74,7 @@ def get_ansible_host(config, inventory, host, ssh_config=None,
     testinfra_host = hostvars.get('ansible_host', host)
     user = hostvars.get('ansible_user')
     port = hostvars.get('ansible_port')
+    password = hostvars.get('ansible_ssh_pass')
     kwargs = {}
     if hostvars.get('ansible_become', False):
         kwargs['sudo'] = True
@@ -92,7 +93,9 @@ def get_ansible_host(config, inventory, host, ssh_config=None,
             'ansible_private_key_file']
 
     spec = '{}://'.format(connection)
-    if user:
+    if user and password:
+        spec += '{}:{}@'.format(user, password)
+    elif user:
         spec += '{}@'.format(user)
     if check_ip_address(testinfra_host) == 6:
         spec += '[' + testinfra_host + ']'


### PR DESCRIPTION
Hi,

I (re) enabled  the ability to use the ansible backend with password taken from ansible's inventory, because it fits my needs. 
[I needed acceptance tests to report on activation of  passwordless authentication on hosts.]

Feel free to merge if you find it usefull.