### PR TITLE
Avoid JSON parsing error in get_ansible_inventory

### DIFF
--- a/testinfra/utils/ansible_runner.py
+++ b/testinfra/utils/ansible_runner.py
@@ -50,7 +50,9 @@ def get_ansible_config():
 
 
 def get_ansible_inventory(config, inventory_file):
-    cmd = 'ansible-inventory --list'
+    # Disable ansible verbosity to avoid
+    # https://github.com/ansible/ansible/issues/59973
+    cmd = 'ANSIBLE_VERBOSITY=0 ansible-inventory --list'
     args = []
     if inventory_file:
         cmd += ' -i %s'


### PR DESCRIPTION
Avoids Ansible bug https://github.com/ansible/ansible/issues/59973 which
prevents testinfra from parsing inventory by disabling ansible verbosity.

Fixes: #470