### PR TITLE
ansible: allow to use ansible for all commands with force_ansible=True.

### DIFF
--- a/doc/source/backends.rst
+++ b/doc/source/backends.rst
@@ -78,13 +78,20 @@ Hosts can be seleted by using the `glob` and `compound matchers
 ansible
 ~~~~~~~
 
-The ansible backend is able to parse ansible inventories to get host connection
-details, including ``ansible_become`` and ``ansible_become_user``. It only
-works with local, ssh or docker hosts::
+The ansible backend is able to parse ansible inventories to get host connection details.
+For local, ssh, paramiko or docker connections it will use the equivalent
+testinfra connection backend, unless `force_ansible=True`.
+
+For other connections types or when `force_ansible=True`, testinfra will run
+all commands through ansible, which is substantially slower than using native
+connections backends.
+
+Examples::
 
     $ py.test --hosts=all # tests all inventory hosts
     $ py.test --hosts='ansible://host1,ansible://host2'
     $ py.test --hosts='ansible://web*'
+    $ py.test --hosts='ansible://host?force_ansible=True'
 
 kubectl
 ~~~~~~~

--- a/testinfra/backend/__init__.py
+++ b/testinfra/backend/__init__.py
@@ -48,7 +48,7 @@ def parse_hostspec(hostspec):
         kw["connection"] = url.scheme
         host = url.netloc
         query = urllib.parse.parse_qs(url.query)
-        for key in ('sudo', 'ssl', 'no_ssl', 'no_verify_ssl'):
+        for key in ('sudo', 'ssl', 'no_ssl', 'no_verify_ssl', 'force_ansible'):
             if query.get(key, ['false'])[0].lower() == 'true':
                 kw[key] = True
         for key in ("sudo_user", 'namespace', 'container', 'read_timeout_sec',

--- a/testinfra/backend/ansible.py
+++ b/testinfra/backend/ansible.py
@@ -28,11 +28,13 @@ class AnsibleBackend(base.BaseBackend):
     HAS_RUN_ANSIBLE = True
 
     def __init__(self, host, ansible_inventory=None, ssh_config=None,
-                 ssh_identity_file=None, *args, **kwargs):
+                 ssh_identity_file=None, force_ansible=False,
+                 *args, **kwargs):
         self.host = host
         self.ansible_inventory = ansible_inventory
         self.ssh_config = ssh_config
         self.ssh_identity_file = ssh_identity_file
+        self.force_ansible = force_ansible
         super(AnsibleBackend, self).__init__(host, *args, **kwargs)
 
     @property
@@ -41,9 +43,16 @@ class AnsibleBackend(base.BaseBackend):
 
     def run(self, command, *args, **kwargs):
         command = self.get_command(command, *args)
-        return self.ansible_runner.run(
-            self.host, command, ssh_config=self.ssh_config,
-            ssh_identity_file=self.ssh_identity_file)
+        if not self.force_ansible:
+            host = self.ansible_runner.get_host(
+                self.host, ssh_config=self.ssh_config,
+                ssh_identity_file=self.ssh_identity_file)
+            if host is not None:
+                return host.run(command)
+        out = self.run_ansible('shell', module_args=command, check=False)
+        return self.result(
+            out['rc'], command, stdout_bytes=None,
+            stderr_bytes=None, stdout=out['stdout'], stderr=out['stderr'])
 
     def run_ansible(self, module_name, module_args=None, **kwargs):
         result = self.ansible_runner.run_module(

--- a/testinfra/utils/ansible_runner.py
+++ b/testinfra/utils/ansible_runner.py
@@ -69,8 +69,8 @@ def get_ansible_host(config, inventory, host, ssh_config=None,
     if connection not in (
         'smart', 'ssh', 'paramiko_ssh', 'local', 'docker', 'lxc', 'lxd',
     ):
-        raise NotImplementedError(
-            'unhandled ansible_connection {}'.format(connection))
+        # unhandled connection type, must use force_ansible=True
+        return None
     connection = {
         'lxd': 'lxc',
         'paramiko_ssh': 'paramiko',
@@ -183,9 +183,6 @@ class AnsibleRunner(object):
             self._host_cache[host] = get_ansible_host(
                 self.ansible_config, self.inventory, host, **kwargs)
             return self._host_cache[host]
-
-    def run(self, host, command, **kwargs):
-        return self.get_host(host, **kwargs).run(command)
 
     def run_module(self, host, module_name, module_args, become=False,
                    check=True, **kwargs):


### PR DESCRIPTION
Since testinfra 3.X we use our own implementation for local, paramiko,
ssh and docker connections for ansible hosts (by parsing the inventory
to get connections details).

This break other connections handled by ansible which where handled in
testinfra 2.X.

Add a force_ansible (default False) parameter to the ansible backend.

When force_ansible is set to True, testinfra will call ansible for all
remote command.

When ansible inventory parsing detect an unhandled connection type (for
example "network_cli"), it will call ansible for all remote commands as
well.

Add tests by adding a new host with "force_ansible=True" in existing
backend tests. Also expand HOSTS, SUDO_HOSTS etc, this is less "DRY" but
more explicit.
There's a known encoding issue with ansible (it was already present in
testinfra 2.X), just adapt the test for ansible here.

Closes #453
Related to #467