### PR TITLE
Fix safe-ssh backend with shell redirections

### DIFF
--- a/test/test_backends.py
+++ b/test/test_backends.py
@@ -63,6 +63,19 @@ def test_command(host):
     assert host.check_output("true") == ""
     # test that quotting is correct
     assert host.run("echo a b | grep -q %s", "a c").rc == 1
+    out = host.run("echo out && echo err >&2 && exit 42")
+    assert out.rc == 42
+    if (
+        host.backend.get_connection_type() == "ansible"
+        and host.backend.force_ansible
+    ):
+        assert out.stdout_bytes == b'out'
+        assert out.stderr_bytes == b'err'
+    else:
+        assert out.stdout_bytes == b'out\n'
+        assert out.stderr_bytes == b'err\n'
+    out = host.run("commandthatdoesnotexists")
+    assert out.rc == 127
 
 
 @pytest.mark.testinfra_hosts(*HOSTS)

--- a/testinfra/backend/ssh.py
+++ b/testinfra/backend/ssh.py
@@ -91,6 +91,7 @@ class SafeSshBackend(SshBackend):
 
     def run(self, command, *args, **kwargs):
         orig_command = self.get_command(command, *args)
+        orig_command = self.get_command('sh -c %s', orig_command)
 
         out = self.run_ssh((
             '''of=$(mktemp)&&ef=$(mktemp)&&%s >$of 2>$ef; r=$?;'''


### PR DESCRIPTION
safe-ssh already use a lot of redirection and was expecting the input
command was a single command with arguments.

When testing with more complex commands, the code may crash.
Avoid this by wrapping the command in a "sh -c" execution.

Add a sanity check for "host.run()" testing exit code, stdout and stderr
are decoded correctly for all tested backends (ssh, safe-ssh, paramiko,
ansible, ansible with force_ansible etc).