### PR TITLE
Fix pure ansible connections with ANSIBLE_ANY_ERRORS_FATAL=True

### DIFF
--- a/test/test_backends.py
+++ b/test/test_backends.py
@@ -95,6 +95,19 @@ def test_encoding(host):
         )
 
 
+@pytest.mark.testinfra_hosts(
+    "ansible://debian_stretch?force_ansible=True")
+def test_ansible_any_error_fatal(host):
+    os.environ['ANSIBLE_ANY_ERRORS_FATAL'] = 'True'
+    try:
+        out = host.run("echo out && echo err >&2 && exit 42")
+        assert out.rc == 42
+        assert out.stdout == 'out'
+        assert out.stderr == 'err'
+    finally:
+        del os.environ['ANSIBLE_ANY_ERRORS_FATAL']
+
+
 @pytest.mark.testinfra_hosts(*(USER_HOSTS + SUDO_USER_HOSTS))
 def test_user_connection(host):
     assert host.user().name == "user"

--- a/testinfra/utils/ansible_runner.py
+++ b/testinfra/utils/ansible_runner.py
@@ -203,7 +203,7 @@ class AnsibleRunner(object):
         args += [host]
         with TemporaryDirectory() as d:
             args[0] = d
-            out = local.run_expect([0, 2], cmd, *args)
+            out = local.run_expect([0, 2, 8], cmd, *args)
             files = os.listdir(d)
             if not files and 'skipped' in out.stdout.lower():
                 return {'failed': True, 'skipped': True,


### PR DESCRIPTION
When ANSIBLE_ANY_ERRORS_FATAL is set to True (this can be set from
environment, and probably from inventory or ansible configuration
files), the ansible call exit with status 8 when running a command that
fail to run.

Detail of exit codes can be found here:
https://github.com/ansible/ansible/blob/523e40e993c06a6c15234c9a3c951b5398e44184/lib/ansible/executor/task_queue_manager.py#L63-L68

Add `8` to the expected exit codes and add a non regression test.

Closes #481