### PR TITLE
Add BlockDevice module to query block device info.

### DIFF
--- a/testinfra/modules/__init__.py
+++ b/testinfra/modules/__init__.py
@@ -38,6 +38,7 @@ modules = {
     'sysctl': 'sysctl:Sysctl',
     'system_info': 'systeminfo:SystemInfo',
     'user': 'user:User',
+    'block_device': 'blockdevice:BlockDevice',
 }
 
 

--- a/testinfra/modules/blockdevice.py
+++ b/testinfra/modules/blockdevice.py
@@ -66,8 +66,9 @@ class BlockDevice(Module):
 
     @property
     def size(self):
-        """Return size if the device in bytes or None
-           if device is not a block device.
+        """Return size if the device in bytes.
+
+           Return None if device is not a block device.
 
         >>> host.block_device("/dev/sda1").size
         512110190592

--- a/testinfra/modules/blockdevice.py
+++ b/testinfra/modules/blockdevice.py
@@ -131,15 +131,15 @@ class LinuxBlockDevice(BlockDevice):
 
     @cached_property
     def _data(self):
-        HEADER = ['RO', 'RA', 'SSZ', 'BSZ', 'StartSec', 'Size', 'Device']
-        COMMAND = 'blockdev  --report %s'
-        blockdev = self.run(COMMAND % self.device)
+        header = ['RO', 'RA', 'SSZ', 'BSZ', 'StartSec', 'Size', 'Device']
+        command = 'blockdev  --report %s'
+        blockdev = self.run(command % self.device)
         if blockdev.rc != 0 or len(blockdev.stderr) > 0:
             raise RuntimeError("Failed to gather data: %s" % blockdev.stderr)
         output = blockdev.stdout.splitlines()
         if len(output) < 2:
             raise RuntimeError("No data from %s" % self.device)
-        if output[0].split() != HEADER:
+        if output[0].split() != header:
             raise RuntimeError('Unknown output of blockdev: %s' % output[0])
         fields = output[1].split()
         return {

--- a/testinfra/modules/blockdevice.py
+++ b/testinfra/modules/blockdevice.py
@@ -1,0 +1,223 @@
+# coding: utf-8
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import unicode_literals
+
+from testinfra.modules.base import Module
+
+
+class BlockDevice(Module):
+    """Information for block device.
+
+       Should be used with sudo or under root.
+    """
+
+    def __init__(self, device):
+        self.device = device
+        self._data_cache = None
+        super(BlockDevice, self).__init__()
+
+    @classmethod
+    def _probe_device(cls, device):
+        raise NotImplementedError
+
+    @property
+    def is_block_device(self):
+        """Return True if the device is a proper block device.
+
+        Proper block device:
+        * is a device which can report block device size (GETSIZE64)
+        * size is greater than zero
+
+        >>> host.block_device("/dev/sda5").is_block_device
+        True
+
+        >>> host.block_device("/dev/console").is_block_device
+        False
+
+        """
+        is_proper = self._data['is_block_device'] and \
+            self._data['size'] > 0
+
+        return is_proper
+
+    @property
+    def is_partition(self):
+        """Return True if the device is a partition.
+
+        >>> host.block_device("/dev/sda1").is_partition
+        True
+
+        >>> host.block_device("/dev/sda").is_partition
+        False
+
+        """
+        return self.is_block_device and self._data['start_sector'] > 0
+
+    @property
+    def size(self):
+        """Return size if the device in bytes or None
+           if device is not a block device.
+
+        >>> host.block_device("/dev/sda1").size
+        512110190592
+
+        >>> print(host.block_device("/dev/console").size)
+        None
+
+        """
+        if not self.is_block_device:
+            return None
+        return self._data['size']
+
+    @property
+    def sector_size(self):
+        """Return sector size for the device in bytes or None if device
+           is not a block device.
+
+        >>> host.block_device("/dev/sda1").sector_szie
+        512
+
+        >>> print(host.block_device("/dev/console").sector_szie)
+        None
+
+        """
+        if not self.is_block_device:
+            return None
+        return self._data['sector_size']
+
+    @property
+    def block_size(self):
+        """Return block size for the device in bytes or None if device
+           is not a block device.
+
+        >>> host.block_device("/dev/sda").block_szie
+        4096
+
+        >>> print(host.block_device("/dev/console").block_size)
+        None
+
+        """
+        if not self.is_block_device:
+            return None
+        return self._data['block_size']
+
+    @property
+    def start_sector(self):
+        """Return start sector of the device on the underlaying device.
+           Usually the value is zero for full devices and is non-zero
+           for partitions.
+           Return None if device is not a block device.
+
+        >>> host.block_device("/dev/sda1").start_sector
+        2048
+
+        >>> host.block_device("/dev/md0").start_sector
+        0
+
+        >>> print(host.block_device("/dev/console").start_sector)
+        None
+
+        """
+        if not self.is_block_device:
+            return None
+        return self._data['sector_size']
+
+    @property
+    def is_writable(self):
+        """Return True if device is writable (have no RO status), or None
+           if device is not a proper block device.
+
+        >>> host.block_device("/dev/sda").is_writable
+        True
+
+        >>> host.block_device("/dev/loop1").is_writable
+        False
+
+        >>> host.block_device("/dev/console").is_writable
+        None
+
+        """
+        if not self.is_block_device:
+            return None
+        mode = self._data['rw_mode']
+        if mode == 'rw':
+            return True
+        elif mode == 'ro':
+            return False
+        else:
+            raise ValueError('Unexpected value for rw: %s' % mode)
+
+    @property
+    def ra(self):
+        """Return Read Ahead parameter for the device in 512-bytes sectors
+           or None if device is not a proper block device.
+
+        >>> host.block_device("/dev/sda").ra
+        256
+
+        >>> print(host.block_device("/dev/console").ra)
+        None
+        """
+        if not self.is_block_device:
+            return None
+        return self._data['read_ahead']
+
+    @property
+    def _data(self):
+        if self._data_cache is None:
+            self._data_cache = self._probe_device(self.device)
+        return self._data_cache
+
+    @classmethod
+    def get_module_class(cls, host):
+        if host.system_info.type == 'linux':
+            return LinuxBlockDevice
+        # if host.system_info.type.endswith("bsd"):
+        #     return BSDlockDevice
+        raise NotImplementedError
+
+    def __repr__(self):
+        return '<BlockDevice(path=%s)>' % self.device
+
+
+class LinuxBlockDevice(BlockDevice):
+
+    @classmethod
+    def _probe_device(cls, device):
+        HEADER = ['RO', 'RA', 'SSZ', 'BSZ', 'StartSec', 'Size', 'Device']
+        COMMAND = 'blockdev  --report %s'
+        run = cls(None).run
+        blockdev = run(COMMAND % device)
+        if blockdev.rc != 0:
+            return {
+                'is_block_device': False,
+                'rw_mode': None,
+                'read_ahead': None,
+                'sector_size': None,
+                'block_size': None,
+                'start_sector': None,
+                'size': None
+            }
+        output = blockdev.stdout.splitlines()
+        assert output[0].split() == HEADER, 'Unknown output of blkid'
+        fields = output[1].split()
+        return {
+            'is_block_device': True,
+            'rw_mode': str(fields[0]),
+            'read_ahead': int(fields[1]),
+            'sector_size': int(fields[2]),
+            'block_size': int(fields[3]),
+            'start_sector': int(fields[4]),
+            'size': int(fields[5])
+        }

--- a/testinfra/modules/blockdevice.py
+++ b/testinfra/modules/blockdevice.py
@@ -82,8 +82,7 @@ class BlockDevice(Module):
 
     @property
     def sector_size(self):
-        """Return sector size for the device in bytes or None if device
-           is not a block device.
+        """Return sector size for the device in bytes or None.
 
         >>> host.block_device("/dev/sda1").sector_szie
         512
@@ -98,8 +97,7 @@ class BlockDevice(Module):
 
     @property
     def block_size(self):
-        """Return block size for the device in bytes or None if device
-           is not a block device.
+        """Return block size for the device in bytes or None.
 
         >>> host.block_device("/dev/sda").block_szie
         4096
@@ -115,6 +113,7 @@ class BlockDevice(Module):
     @property
     def start_sector(self):
         """Return start sector of the device on the underlaying device.
+
            Usually the value is zero for full devices and is non-zero
            for partitions.
            Return None if device is not a block device.
@@ -135,8 +134,7 @@ class BlockDevice(Module):
 
     @property
     def is_writable(self):
-        """Return True if device is writable (have no RO status), or None
-           if device is not a proper block device.
+        """Return True if device is writable (have no RO status), or None.
 
         >>> host.block_device("/dev/sda").is_writable
         True
@@ -155,13 +153,11 @@ class BlockDevice(Module):
             return True
         elif mode == 'ro':
             return False
-        else:
-            raise ValueError('Unexpected value for rw: %s' % mode)
+        raise ValueError('Unexpected value for rw: %s' % mode)
 
     @property
     def ra(self):
-        """Return Read Ahead parameter for the device in 512-bytes sectors
-           or None if device is not a proper block device.
+        """Return Read Ahead for the device in 512-bytes sectors or None.
 
         >>> host.block_device("/dev/sda").ra
         256

--- a/testinfra/modules/blockdevice.py
+++ b/testinfra/modules/blockdevice.py
@@ -85,10 +85,10 @@ class BlockDevice(Module):
     def sector_size(self):
         """Return sector size for the device in bytes or None.
 
-        >>> host.block_device("/dev/sda1").sector_szie
+        >>> host.block_device("/dev/sda1").sector_size
         512
 
-        >>> print(host.block_device("/dev/console").sector_szie)
+        >>> print(host.block_device("/dev/console").sector_size)
         None
 
         """
@@ -100,7 +100,7 @@ class BlockDevice(Module):
     def block_size(self):
         """Return block size for the device in bytes or None.
 
-        >>> host.block_device("/dev/sda").block_szie
+        >>> host.block_device("/dev/sda").block_size
         4096
 
         >>> print(host.block_device("/dev/console").block_size)

--- a/testinfra/modules/blockdevice.py
+++ b/testinfra/modules/blockdevice.py
@@ -140,7 +140,7 @@ class LinuxBlockDevice(BlockDevice):
         if len(output) < 2:
             raise RuntimeError("No data from %s" % self.device)
         if output[0].split() != HEADER:
-            raise RuntimeError('Unknown output of blkid: %s' % output[0])
+            raise RuntimeError('Unknown output of blockdev: %s' % output[0])
         fields = output[1].split()
         return {
             'rw_mode': str(fields[0]),

--- a/testinfra/modules/blockdevice.py
+++ b/testinfra/modules/blockdevice.py
@@ -151,7 +151,7 @@ class BlockDevice(Module):
         mode = self._data['rw_mode']
         if mode == 'rw':
             return True
-        elif mode == 'ro':
+        if mode == 'ro':
             return False
         raise ValueError('Unexpected value for rw: %s' % mode)
 

--- a/testinfra/modules/blockdevice.py
+++ b/testinfra/modules/blockdevice.py
@@ -134,7 +134,7 @@ class LinuxBlockDevice(BlockDevice):
         header = ['RO', 'RA', 'SSZ', 'BSZ', 'StartSec', 'Size', 'Device']
         command = 'blockdev  --report %s'
         blockdev = self.run(command % self.device)
-        if blockdev.rc != 0 or len(blockdev.stderr) > 0:
+        if blockdev.rc != 0 or blockdev.stderr:
             raise RuntimeError("Failed to gather data: %s" % blockdev.stderr)
         output = blockdev.stdout.splitlines()
         if len(output) < 2:

--- a/testinfra/modules/blockdevice.py
+++ b/testinfra/modules/blockdevice.py
@@ -119,8 +119,6 @@ class BlockDevice(Module):
     def get_module_class(cls, host):
         if host.system_info.type == 'linux':
             return LinuxBlockDevice
-        # if host.system_info.type.endswith("bsd"):
-        #     return BSDlockDevice  # please, implement this
         raise NotImplementedError
 
     def __repr__(self):


### PR DESCRIPTION
I found I need some block device info for my tests, and testinfra got no such module, so I wrote it.

It is a wrapper over `blockdev --report` with some logic on top.

Gathered information:

* size
* r/w or r/o status
* sector_size
* block_size
* partition or not
* read ahead value
* basic sanity check (`is_block_device`)