### PR TITLE
ansible: raise an error in case of empty inventory

### DIFF
--- a/test/test_backends.py
+++ b/test/test_backends.py
@@ -284,8 +284,15 @@ def test_ansible_no_host():
     with tempfile.NamedTemporaryFile() as f:
         # empty or no inventory should not return any hosts except for
         # localhost
-        assert AnsibleRunner(f.name).get_hosts() == []
-        assert AnsibleRunner(f.name).get_hosts('local*') == []
+        nohost = (
+            'No inventory was parsed (missing file ?), '
+            'only implicit localhost is available')
+        with pytest.raises(RuntimeError) as exc:
+            assert AnsibleRunner(f.name).get_hosts() == []
+        assert str(exc.value) == nohost
+        with pytest.raises(RuntimeError) as exc:
+            assert AnsibleRunner(f.name).get_hosts('local*') == []
+        assert str(exc.value) == nohost
         assert AnsibleRunner(f.name).get_hosts('localhost') == ['localhost']
 
 

--- a/testinfra/utils/ansible_runner.py
+++ b/testinfra/utils/ansible_runner.py
@@ -63,7 +63,9 @@ def get_ansible_inventory(config, inventory_file):
 def get_ansible_host(config, inventory, host, ssh_config=None,
                      ssh_identity_file=None):
     if is_empty_inventory(inventory):
-        return testinfra.get_host('local://')
+        if host == 'localhost':
+            return testinfra.get_host('local://')
+        return None
     hostvars = inventory['_meta'].get('hostvars', {}).get(host, {})
     connection = hostvars.get('ansible_connection', 'ssh')
     if connection not in (
@@ -139,6 +141,10 @@ class AnsibleRunner(object):
             # empty inventory should not return any hosts except for localhost
             if pattern == 'localhost':
                 result.add('localhost')
+            else:
+                raise RuntimeError(
+                    'No inventory was parsed (missing file ?), '
+                    'only implicit localhost is available')
         else:
             for group in inventory:
                 groupmatch = fnmatch.fnmatch(group, pattern)


### PR DESCRIPTION
When inventory is empty or an unexistent file, ansible-inventory will
not raise an error but just a warning:

% ansible-inventory --list -i /doesnotexists
 [WARNING]: Unable to parse /doesnotexists as an inventory source

 [WARNING]: No inventory was parsed, only implicit localhost is
available

{
    "_meta": {
        "hostvars": {}
    },
    "all": {
        "children": [
            "ungrouped"
        ]
    },
    "ungrouped": {}
}
% echo $?
0

Raise an error when inventory is empty and host is not explicitly set to
localhost.

This mean:

python -m pytest --ansible-inventory /doesnotexists --connection ansible => RAISE
python -m pytest --ansible-inventory /doesnotexists --connection ansible --hosts all => RAISE
python -m pytest --ansible-inventory /doesnotexists --connection ansible --hosts 'local*' => RAISE
python -m pytest --ansible-inventory /doesnotexists --connection ansible --hosts 'localhost' => does not raise

Closes #489