### PR TITLE
ansible: fix ansible ssh args escaping

### DIFF
--- a/test/test_backends.py
+++ b/test/test_backends.py
@@ -199,21 +199,21 @@ def test_ansible_get_variables():
         }
 
 
-@pytest.mark.parametrize('hostname,kwargs,inventory,expected', [
-    ('host', {}, b'host ansible_connection=local ansible_become=yes ansible_become_user=u', {  # noqa
+@pytest.mark.parametrize('kwargs,inventory,expected', [
+    ({}, b'host ansible_connection=local ansible_become=yes ansible_become_user=u', {  # noqa
         'NAME': 'local',
         'sudo': True,
         'sudo_user': 'u',
     }),
-    ('host', {}, b'host', {
+    ({}, b'host', {
         'NAME': 'ssh',
         'host.name': 'host',
     }),
-    ('host', {}, b'host ansible_connection=smart', {
+    ({}, b'host ansible_connection=smart', {
         'NAME': 'ssh',
         'host.name': 'host',
     }),
-    ('host', {}, b'host ansible_host=127.0.1.1 ansible_user=u ansible_ssh_private_key_file=key ansible_port=2222 ansible_become=yes ansible_become_user=u', {  # noqa
+    ({}, b'host ansible_host=127.0.1.1 ansible_user=u ansible_ssh_private_key_file=key ansible_port=2222 ansible_become=yes ansible_become_user=u', {  # noqa
         'NAME': 'ssh',
         'sudo': True,
         'sudo_user': 'u',
@@ -221,7 +221,7 @@ def test_ansible_get_variables():
         'host.port': '2222',
         'ssh_identity_file': 'key',
     }),
-    ('host', {}, b'host ansible_host=127.0.1.1 ansible_user=u ansible_private_key_file=key ansible_port=2222 ansible_become=yes ansible_become_user=u', {  # noqa
+    ({}, b'host ansible_host=127.0.1.1 ansible_user=u ansible_private_key_file=key ansible_port=2222 ansible_become=yes ansible_become_user=u', {  # noqa
         'NAME': 'ssh',
         'sudo': True,
         'sudo_user': 'u',
@@ -229,34 +229,34 @@ def test_ansible_get_variables():
         'host.port': '2222',
         'ssh_identity_file': 'key',
     }),
-    ('host', {}, b'host ansible_ssh_common_args="-o LogLevel=FATAL"', {
+    ({}, b'host ansible_ssh_common_args="-o LogLevel=FATAL"', {
         'NAME': 'ssh',
         'host.name': 'host',
         'ssh_extra_args': '-o LogLevel=FATAL',
     }),
-    ('host', {}, b'host ansible_ssh_extra_args="-o LogLevel=FATAL"', {
+    ({}, b'host ansible_ssh_extra_args="-o LogLevel=FATAL"', {
         'NAME': 'ssh',
         'host.name': 'host',
         'ssh_extra_args': '-o LogLevel=FATAL',
     }),
-    ('host', {}, b'host ansible_ssh_common_args="-o StrictHostKeyChecking=no" ansible_ssh_extra_args="-o LogLevel=FATAL"', {  # noqa
+    ({}, b'host ansible_ssh_common_args="-o StrictHostKeyChecking=no" ansible_ssh_extra_args="-o LogLevel=FATAL"', {  # noqa
         'NAME': 'ssh',
         'host.name': 'host',
         'ssh_extra_args': '-o StrictHostKeyChecking=no -o LogLevel=FATAL',
     }),
-    ('host', {}, b'host ansible_connection=docker', {
+    ({}, b'host ansible_connection=docker', {
         'NAME': 'docker',
         'name': 'host',
         'user': None,
     }),
-    ('host', {}, b'host ansible_connection=docker ansible_become=yes ansible_become_user=u ansible_user=z ansible_host=container', {  # noqa
+    ({}, b'host ansible_connection=docker ansible_become=yes ansible_become_user=u ansible_user=z ansible_host=container', {  # noqa
         'NAME': 'docker',
         'name': 'container',
         'user': 'z',
         'sudo': True,
         'sudo_user': 'u',
     }),
-    ('host', {'ssh_config': '/ssh_config', 'ssh_identity_file': '/id_ed25519'},
+    ({'ssh_config': '/ssh_config', 'ssh_identity_file': '/id_ed25519'},
         b'host', {
         'NAME': 'ssh',
         'host.name': 'host',
@@ -264,11 +264,11 @@ def test_ansible_get_variables():
         'ssh_identity_file': '/id_ed25519',
     }),
 ])
-def test_ansible_get_host(hostname, kwargs, inventory, expected):
+def test_ansible_get_host(kwargs, inventory, expected):
     with tempfile.NamedTemporaryFile() as f:
         f.write(inventory + b'\n')
         f.flush()
-        backend = AnsibleRunner(f.name).get_host(hostname, **kwargs).backend
+        backend = AnsibleRunner(f.name).get_host('host', **kwargs).backend
         for attr, value in expected.items():
             assert operator.attrgetter(attr)(backend) == value
 

--- a/testinfra/backend/ssh.py
+++ b/testinfra/backend/ssh.py
@@ -40,7 +40,7 @@ class SshBackend(base.BaseBackend):
         cmd = ["ssh"]
         cmd_args = []
         if self.ssh_extra_args:
-            cmd += [self.ssh_extra_args]
+            cmd.append(self.ssh_extra_args.replace('%', '%%'))
         if self.ssh_config:
             cmd.append("-F %s")
             cmd_args.append(self.ssh_config)
@@ -53,8 +53,11 @@ class SshBackend(base.BaseBackend):
         if self.ssh_identity_file:
             cmd.append("-i %s")
             cmd_args.append(self.ssh_identity_file)
-        cmd.append("-o ConnectTimeout={}".format(self.timeout))
-        if self.controlpersist:
+        if 'connecttimeout' not in (self.ssh_extra_args or '').lower():
+            cmd.append("-o ConnectTimeout={}".format(self.timeout))
+        if self.controlpersist and (
+            'controlmaster' not in (self.ssh_extra_args or '').lower()
+        ):
             cmd.append("-o ControlMaster=auto -o ControlPersist=%ds" % (
                 self.controlpersist))
         cmd.append("%s %s")


### PR DESCRIPTION
% sign need to be escaped from format string.
    
Also avoid double ControlMaster/ControlPersist/ConnectTimeout in ssh command.
    
Closes #486
