### PR TITLE
Fix #505

### DIFF
--- a/testinfra/modules/process.py
+++ b/testinfra/modules/process.py
@@ -132,7 +132,7 @@ class PosixProcess(Process):
         attributes -= set(["lstart", "args"])
         attributes = sorted(attributes)
         attributes.extend(["lstart", "args"])
-        arg = ",".join(attributes)
+        arg = ":50,".join(attributes)
 
         procs = []
         # skip first line (header)


### PR DESCRIPTION
The -o flag in the ps command allow to specify the column width, so setting a fixed, and relatively wide value, should fix the issue.