### PR TITLE
Implement File.list_dir to list items in a directory

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -16,6 +16,7 @@ disable=
 max-branches=20
 max-bool-expr=6
 max-args=8
+max-public-methods=30
 # we have flake8 for that
 max-line-length=1000
 generated-members=check_output,run_test,run_expect,run,find_command

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -276,10 +276,12 @@ def test_local_command(host):
 
 def test_file(host):
     host.check_output("mkdir -p /d && printf foo > /d/f && chmod 600 /d/f")
+    host.check_output('touch "/d/f\nl"')
+    host.check_output('touch "/d/f s"')
     d = host.file("/d")
     assert d.is_directory
     assert not d.is_file
-    assert d.listdir == ["f"]
+    assert d.listdir == ["f", "f?l", "f s"]
     f = host.file("/d/f")
     assert f.exists
     assert f.is_file

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -279,6 +279,7 @@ def test_file(host):
     d = host.file("/d")
     assert d.is_directory
     assert not d.is_file
+    assert d.list_dir == ["f"]
     f = host.file("/d/f")
     assert f.exists
     assert f.is_file

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -279,7 +279,7 @@ def test_file(host):
     d = host.file("/d")
     assert d.is_directory
     assert not d.is_file
-    assert d.list_dir == ["f"]
+    assert d.listdir == ["f"]
     f = host.file("/d/f")
     assert f.exists
     assert f.is_file

--- a/testinfra/modules/file.py
+++ b/testinfra/modules/file.py
@@ -176,7 +176,7 @@ class File(Module):
         >>> host.file("/tmp").listdir
         ['foo_file', 'bar_dir']
         """
-        out = self.run_test("ls -- %s", self.path)
+        out = self.run_test("ls -1 -q -- %s", self.path)
         if out.rc != 0:
             raise RuntimeError("Unexpected output %s" % (out,))
         return out.stdout.splitlines()

--- a/testinfra/modules/file.py
+++ b/testinfra/modules/file.py
@@ -170,10 +170,10 @@ class File(Module):
         raise NotImplementedError
 
     @property
-    def list_dir(self):
+    def listdir(self):
         """Return list of items under the directory
 
-        >>> host.file("/tmp").list_dir
+        >>> host.file("/tmp").listdir
         ['foo_file', 'bar_dir']
         """
         out = self.run_test("ls -- %s", self.path)

--- a/testinfra/modules/file.py
+++ b/testinfra/modules/file.py
@@ -169,6 +169,18 @@ class File(Module):
         """Return size of file in bytes"""
         raise NotImplementedError
 
+    @property
+    def list_dir(self):
+        """Return list of items under the directory
+
+        >>> host.file("/tmp").list_dir
+        ['foo_file', 'bar_dir']
+        """
+        out = self.run_test("ls -- %s", self.path)
+        if out.rc != 0:
+            raise RuntimeError("Unexpected output %s" % (out,))
+        return out.stdout.splitlines()
+
     def __repr__(self):
         return "<file %s>" % (self.path,)
 


### PR DESCRIPTION
So that users can assert on items in a directory. Just like the [File.content](https://github.com/philpep/testinfra/blob/02a9338b1e8eef7da8737099ee1445341e454fe1/testinfra/modules/file.py#L141) which is useful to assert if a file content contains a certain value, but for directory items.