### PR TITLE
ansible + ssh backend: support for passwords via sshpass

### DIFF
--- a/doc/source/backends.rst
+++ b/doc/source/backends.rst
@@ -79,12 +79,17 @@ ansible
 ~~~~~~~
 
 The ansible backend is able to parse ansible inventories to get host connection details.
-For local, ssh, paramiko or docker connections it will use the equivalent
-testinfra connection backend, unless `force_ansible=True` (or ``--force-ansible``) is set.
+For local, ssh, paramiko or docker connections(based on `ansible_connection` value) 
+it will use the equivalent testinfra connection backend, unless `force_ansible=True` 
+(or ``--force-ansible``) is set.
 
 For other connections types or when `force_ansible=True`, testinfra will run
 all commands through ansible, which is substantially slower than using native
 connections backends.
+
+If ssh identity file is not provided via `--ssh-identity-file` flag, testinfra will try 
+to use `ansible_ssh_private_key_file`, `ansible_private_key_file` and, finally, 
+`ansible_user` with `ansible_ssh_pass` variables, both should be specified.
 
 Examples::
 

--- a/test/test_backends.py
+++ b/test/test_backends.py
@@ -277,6 +277,20 @@ def test_ansible_get_host(kwargs, inventory, expected):
     (b'host', (
         'ssh -o ConnectTimeout=10 -o ControlMaster=auto '
         '-o ControlPersist=60s host true')),
+    # password passing from inventory: user is required
+    (b'host ansible_user=user ansible_ssh_pass=password', (
+        'sshpass -p password ssh -o User=user '
+        '-o ConnectTimeout=10 -o ControlMaster=auto '
+        '-o ControlPersist=60s host true')),
+    # identity_file has highest priority
+    (b'host ansible_user=user ansible_ssh_pass=password ansible_ssh_private_key_file=some_file', (  # noqa
+        'ssh -o User=user -i some_file '
+        '-o ConnectTimeout=10 -o ControlMaster=auto '
+        '-o ControlPersist=60s host true')),
+    # password without usr won't work
+    (b'host ansible_ssh_pass=password', (
+        'ssh -o ConnectTimeout=10 -o ControlMaster=auto '
+        '-o ControlPersist=60s host true')),
     # avoid interference between our ssh backend and ansible_ssh_extra_args
     (b'host ansible_ssh_extra_args="-o ConnectTimeout=5 -o ControlMaster=auto '
      b'-o ControlPersist=10s"', (

--- a/testinfra/backend/ssh.py
+++ b/testinfra/backend/ssh.py
@@ -37,8 +37,13 @@ class SshBackend(base.BaseBackend):
         return self.run_ssh(self.get_command(command, *args))
 
     def _build_ssh_command(self, command):
-        cmd = ["ssh"]
-        cmd_args = []
+        if not self.host.password:
+            cmd = ['ssh']
+            cmd_args = []
+        else:
+            cmd = ['sshpass', '-p', '%s', 'ssh']
+            cmd_args = [self.host.password]
+
         if self.ssh_extra_args:
             cmd.append(self.ssh_extra_args.replace('%', '%%'))
         if self.ssh_config:

--- a/testinfra/utils/ansible_runner.py
+++ b/testinfra/utils/ansible_runner.py
@@ -80,6 +80,7 @@ def get_ansible_host(config, inventory, host, ssh_config=None,
     }.get(connection, connection)
     testinfra_host = hostvars.get('ansible_host', host)
     user = hostvars.get('ansible_user')
+    password = hostvars.get('ansible_ssh_pass')
     port = hostvars.get('ansible_port')
     kwargs = {}
     if hostvars.get('ansible_become', False):
@@ -103,8 +104,13 @@ def get_ansible_host(config, inventory, host, ssh_config=None,
     ).strip()
 
     spec = '{}://'.format(connection)
-    if user:
+
+    # Fallback to user:pasword auth when identity file is not used
+    if user and password and not kwargs.get('ssh_identity_file'):
+        spec += '{}:{}@'.format(user, password)
+    elif user:
         spec += '{}@'.format(user)
+
     if check_ip_address(testinfra_host) == 6:
         spec += '[' + testinfra_host + ']'
     else:


### PR DESCRIPTION
If ssh identity file is not provided via `--ssh-identity-file` flag, testinfra will try 
to use `ansible_ssh_private_key_file`, `ansible_private_key_file` and, finally, 
`ansible_user` with `ansible_ssh_pass` variables, both should be specified.
