### PR TITLE
Use pytest way of controlling exit status

### DIFF
--- a/testinfra/plugin.py
+++ b/testinfra/plugin.py
@@ -211,7 +211,7 @@ def pytest_configure(config):
 
 
 @pytest.mark.trylast
-def pytest_unconfigure(config):
-    reporter = config.pluginmanager.getplugin('nagiosreporter')
+def pytest_sessionfinish(session, exitstatus):
+    reporter = session.config.pluginmanager.getplugin('nagiosreporter')
     if reporter:
-        sys.exit(reporter.report())
+        session.exitstatus = reporter.report()


### PR DESCRIPTION
Inspired from https://github.com/yashtodi94/pytest-custom_exit_code

This should fix tests failing with pytest 5 due to "sys.exit()" raising
weird behaviors in pytest.

Tested with pytest 5.X, 4.X and 3.X series.