### PR TITLE
Remove --tree None option from ansible runner

### DIFF
--- a/testinfra/utils/ansible_runner.py
+++ b/testinfra/utils/ansible_runner.py
@@ -198,7 +198,7 @@ class AnsibleRunner(object):
 
     def run_module(self, host, module_name, module_args, become=False,
                    check=True, **kwargs):
-        cmd, args = 'ansible --tree %s', [None]
+        cmd, args = 'ansible', []
         if self.inventory_file:
             cmd += ' -i %s'
             args += [self.inventory_file]


### PR DESCRIPTION
`None` has been the default value for tree since the option was added,
https://github.com/ansible/ansible/commit/ab17f6f44e8fc3c15549b6ff4b5c752ef1a79bd9