### PR TITLE
Allow specifying arguments to the Ansible CLI

### DIFF
--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -383,6 +383,17 @@ def test_ansible_module_become(host):
                             check=False, become=True)['stdout'] == 'root'
 
 
+@pytest.mark.testinfra_hosts("ansible://debian_stretch")
+def test_ansible_module_options(host):
+    host.ansible(
+        'command',
+        'id --user --name',
+        check=False,
+        become=True,
+        become_user='nobody',
+    )['stdout'] == 'nobody'
+
+
 @pytest.mark.destructive
 def test_supervisor(host):
     # Wait supervisord is running

--- a/testinfra/modules/ansible.py
+++ b/testinfra/modules/ansible.py
@@ -61,6 +61,20 @@ class Ansible(InstanceModule):
     <https://docs.ansible.com/ansible/user_guide/become.html#id1>`_ is
     `False` by default. You can enable it with `become=True`.
 
+    Ansible arguments that are not related to the Ansible inventory or
+    connection (both managed by testinfra) are also accepted through keyword
+    arguments:
+
+        - ``become_method`` *str* sudo, su, doas, etc.
+        - ``become_user`` *str* become this user.
+        - ``diff`` *bool*: when changing (small) files and templates, show the
+          differences in those files.
+        - ``extra_vars`` *dict* serialized to a JSON string, passed to
+          Ansible.
+        - ``one_line`` *bool*: condense output.
+        - ``user`` *str* connect as this user.
+        - ``verbose`` *int* level of verbosity
+
     >>> host.ansible("apt", "name=nginx state=present")["changed"]
     False
     >>> host.ansible("apt", "name=nginx state=present", become=True)["changed"]
@@ -71,6 +85,21 @@ class Ansible(InstanceModule):
     'jessie'
     >>> host.ansible("file", "path=/etc/passwd")["mode"]
     '0640'
+    >>> host.ansible(
+    ... "command",
+    ... "id --user --name",
+    ... check=False,
+    ... become=True,
+    ... become_user="http",
+    ... )["stdout"]
+    'http'
+    >>> host.ansible(
+    ... "apt",
+    ... "name={{ packages }}",
+    ... check=False,
+    ... extra_vars={"packages": ["neovim", "vim"]},
+    ... )
+    # Installs neovim and vim.
 
     """
     # pylint: disable=self-assigning-variable


### PR DESCRIPTION
Instead of adding a keyword argument for each supported option, allow users to pass arguments directly to the ansible command line.

Support for passing [extra vars](https://docs.ansible.com/ansible/latest/cli/ansible.html#cmdoption-ansible-e) has been proposed in https://github.com/philpep/testinfra/pull/462.

This approach offers support for extra vars, as well as become user, verbosity, running in diff mode, etc.