### PR TITLE
fix test_encoding failing for ansible backend

### DIFF
--- a/images/debian_stretch/Dockerfile
+++ b/images/debian_stretch/Dockerfile
@@ -54,6 +54,7 @@ RUN echo "root:foo" | chpasswd
 
 # Enable ssh login for user and fix side effect on environment variables...
 RUN sed -ri 's/^UsePAM yes$/UsePAM no/' /etc/ssh/sshd_config
+RUN sed -ri 's/AcceptEnv LANG LC_*/#AcceptEnv LANG LC_*/' /etc/ssh/sshd_config
 RUN echo "PermitUserEnvironment yes" >> /etc/ssh/sshd_config
 RUN echo "LANG=fr_FR.ISO-8859-15" >> /root/.ssh/environment
 RUN echo "user:foo" | chpasswd


### PR DESCRIPTION
if LC_* is not `fr_FR.ISO-8859-15` on the system running pytest

# Issue description

from recent master (fc8a824d0f95a672091560f76a5b91e65f1cd6d2), running the test suite from a Linux computer with LC_* environment variables set to `en_US.UTF-8` produces errors for `test_encoding`. 

My locales :

```
LANG=en_US.UTF-8
LANGUAGE=en_US
LC_CTYPE="en_US.UTF-8"
LC_NUMERIC="en_US.UTF-8"
LC_TIME="en_US.UTF-8"
LC_COLLATE="en_US.UTF-8"
LC_MONETARY="en_US.UTF-8"
LC_MESSAGES="en_US.UTF-8"
LC_PAPER="en_US.UTF-8"
LC_NAME="en_US.UTF-8"
LC_ADDRESS="en_US.UTF-8"
LC_TELEPHONE="en_US.UTF-8"
LC_MEASUREMENT="en_US.UTF-8"
LC_IDENTIFICATION="en_US.UTF-8"
LC_ALL=en_US.UTF-8
```

![image](https://user-images.githubusercontent.com/42300/74883846-22983900-5372-11ea-8395-96d6088c5775.png)

Full pytest log is attached : 
[test_encoding_fail.txt](https://github.com/philpep/testinfra/files/4227890/test_encoding_fail.txt)

