### PR TITLE
Make File.listdir a method

### DIFF
--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -278,7 +278,7 @@ def test_file(host):
     d = host.file("/d")
     assert d.is_directory
     assert not d.is_file
-    assert d.listdir == ["f", "f?l", "f s"]
+    assert d.listdir() == ["f", "f?l", "f s"]
     f = host.file("/d/f")
     assert f.exists
     assert f.is_file

--- a/testinfra/modules/file.py
+++ b/testinfra/modules/file.py
@@ -166,11 +166,10 @@ class File(Module):
         """Return size of file in bytes"""
         raise NotImplementedError
 
-    @property
     def listdir(self):
         """Return list of items under the directory
 
-        >>> host.file("/tmp").listdir
+        >>> host.file("/tmp").listdir()
         ['foo_file', 'bar_dir']
         """
         out = self.run_test("ls -1 -q -- %s", self.path)


### PR DESCRIPTION
This documented as a method in 4.1 changelog and it seems more intuitive
this way as it clearly indicates that a computation is performed.