### PR TITLE
Add architecture to sysinfo

### DIFF
--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -90,13 +90,13 @@ def test_uninstalled_package_version(host):
 def test_systeminfo(host, docker_image):
     assert host.system_info.type == "linux"
 
-    release, distribution, codename = {
-        "alpine": (r"^3\.11\.", "alpine", None),
-        "archlinux": ("rolling", "arch", None),
-        "centos_6": (r"^6", "CentOS", None),
-        "centos_7": (r"^7$", "centos", None),
-        "debian_buster": (r"^10", "debian", "buster"),
-        "ubuntu_xenial": (r"^16\.04$", "ubuntu", "xenial")
+    release, distribution, codename, arch = {
+        "alpine": (r"^3\.11\.", "alpine", None, 'x86_64'),
+        "archlinux": ("rolling", "arch", None, 'x86_64'),
+        "centos_6": (r"^6", "CentOS", None, 'x86_64'),
+        "centos_7": (r"^7$", "centos", None, 'x86_64'),
+        "debian_buster": (r"^10", "debian", "buster", 'x86_64'),
+        "ubuntu_xenial": (r"^16\.04$", "ubuntu", "xenial", 'x86_64')
     }[docker_image]
 
     assert host.system_info.distribution == distribution

--- a/testinfra/modules/systeminfo.py
+++ b/testinfra/modules/systeminfo.py
@@ -26,6 +26,7 @@ class SystemInfo(InstanceModule):
             "distribution": None,
             "codename": None,
             "release": None,
+            "arch": None,
         }
         uname = self.run_expect([0, 1], 'uname -s')
         if uname.rc == 1:
@@ -42,6 +43,8 @@ class SystemInfo(InstanceModule):
             sysinfo["release"] = self.check_output("uname -r")
             sysinfo["distribution"] = sysinfo["type"]
             sysinfo["codename"] = None
+
+        sysinfo["arch"] = self.check_output("uname -m")
         return sysinfo
 
     def _get_linux_sysinfo(self):
@@ -128,6 +131,7 @@ class SystemInfo(InstanceModule):
                 sysinfo["type"] = value.split(" ")[1].lower()
             elif key == "os_version":
                 sysinfo["release"] = value
+        sysinfo["arch"] = self.check_output('echo %PROCESSOR_ARCHITECTURE%')
         return sysinfo
 
     @property
@@ -165,3 +169,12 @@ class SystemInfo(InstanceModule):
         'buster'
         """
         return self.sysinfo["codename"]
+
+    @property
+    def arch(self):
+        """Host architecture
+
+        >>> host.system_info.arch
+        'x86_64'
+        """
+        return self.sysinfo["arch"]


### PR DESCRIPTION
This allows you to switch on the host architecture easily.  "uname -m"
seems to be globally acceptable on unix-y hosts, Windows has
%PROCESSOR_ARCHITECTURE%.