### PR TITLE
Add '-w' argument to iptables

### DIFF
--- a/images/centos_6/Dockerfile
+++ b/images/centos_6/Dockerfile
@@ -2,7 +2,7 @@ FROM centos:6
 
 RUN yum clean all && \
     yum -y install \
-      openssh-server && \
+      openssh-server iptables && \
     rm -f /etc/ssh/ssh_host_ecdsa_key /etc/ssh/ssh_host_rsa_key && \
     ssh-keygen -q -N "" -t dsa -f /etc/ssh/ssh_host_ecdsa_key && \
     ssh-keygen -q -N "" -t rsa -f /etc/ssh/ssh_host_rsa_key && \

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -516,6 +516,13 @@ def test_iptables(host):
     assert ssh_rule_str in input_rules
     assert vip_redirect_rule_str in nat_rules
     assert vip_redirect_rule_str in nat_prerouting_rules
+    assert host.iptables._has_w_argument is True
+
+
+@pytest.mark.testinfra_hosts('docker://centos_6')
+def test_iptables_centos6(host):
+    host.iptables.rules()
+    assert host.iptables._has_w_argument is False
 
 
 def test_ip6tables(host):


### PR DESCRIPTION
If multiple tests are executed in parallel (e.g. via pytest-xdist) and
more than one test queries the iptables rules on the same host
simultaneously, the following error will occur:

    E       AssertionError: Unexpected exit code 4 for
    CommandResult(command='iptables -t filter -S', exit_status=4,
    stdout='', stderr='Another app is currently holding the xtables
    lock. Perhaps you want to use the -w option?')

Iptables has an internal lock to prevent multiple simultaneous
invocations.  This change implements that suggestion and adds "-w 90" to
the iptables command so that we will wait up to 90 seconds to obtain the
lock.

Unfortunatelly centos 6 is still maintained but doesn't have support for
iptables with "-w" argument. So we have handle this by trying iptables
with "-w 90", if it fail we retry without this option ("w argument
support" is then cached at host level).