### PR TITLE
Fix is_masked method on systemd service 

### DIFF
--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -133,20 +133,13 @@ def test_ssh_service(host, docker_image):
         assert ssh.is_enabled
 
 
-@all_images
-def test_service_mask(host, docker_image):
-    if docker_image in ("centos_6", "centos_7",
-                        "alpine", "archlinux"):
-        name = "sshd"
-    else:
-        name = "ssh"
-
-    ssh = host.service(name)
-    if isinstance(ssh, SystemdService):
-        host.run("systemctl mask %s", name)
-        assert ssh.is_masked
-        host.run("systemctl unmask %s", name)
-        assert not ssh.is_masked
+def test_service_systemd_mask(host):
+    ssh = host.service("ssh")
+    assert not ssh.is_masked
+    host.run("systemctl mask ssh")
+    assert ssh.is_masked
+    host.run("systemctl unmask ssh")
+    assert not ssh.is_masked
 
 
 @pytest.mark.parametrize("name,running,enabled", [

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -20,6 +20,7 @@ import pytest
 from ipaddress import ip_address
 from ipaddress import IPv4Address
 from ipaddress import IPv6Address
+from testinfra.modules.service import SystemdService
 
 from testinfra.modules.socket import parse_socketspec
 
@@ -130,6 +131,22 @@ def test_ssh_service(host, docker_image):
         assert not ssh.is_enabled
     else:
         assert ssh.is_enabled
+
+
+@all_images
+def test_service_mask(host, docker_image):
+    if docker_image in ("centos_6", "centos_7",
+                        "alpine", "archlinux"):
+        name = "sshd"
+    else:
+        name = "ssh"
+
+    ssh = host.service(name)
+    if isinstance(ssh, SystemdService):
+        host.run("systemctl mask %s", name)
+        assert ssh.is_masked
+        host.run("systemctl unmask %s", name)
+        assert not ssh.is_masked
 
 
 @pytest.mark.parametrize("name,running,enabled", [

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -20,7 +20,6 @@ import pytest
 from ipaddress import ip_address
 from ipaddress import IPv4Address
 from ipaddress import IPv6Address
-from testinfra.modules.service import SystemdService
 
 from testinfra.modules.socket import parse_socketspec
 

--- a/testinfra/modules/service.py
+++ b/testinfra/modules/service.py
@@ -153,7 +153,7 @@ class SystemdService(SysvService):
     @property
     def is_masked(self):
         cmd = self.run_test("systemctl is-enabled %s", self.name)
-        return cmd.rc == 0 and cmd.stdout.strip() == "masked"
+        return cmd.stdout.strip() == "masked"
 
 
 class UpstartService(SysvService):


### PR DESCRIPTION
Hi

I'm sorry but I introduced a bug with my PR #568. The `systemcl is-enabled` command doesn't return 0 when the service is not enabled. So my check `cmd.rc == 0` was not relevant in this case.

Sorry for this bug. I add on test to check if my code is valid. This time, it should be ok !