### PR TITLE
Rename project to pytest-infra

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-name = testinfra
+name = pytest-testinfra
 url = https://github.com/philpep/testinfra
 description = Test infrastructures
 long_description = file:README.rst


### PR DESCRIPTION
As part of migrating the project under pytest-dev organization, we need to rename the package and repository name. The installed python module remains testinfra.

pypi and testpypi have already being bootstrapped with `5.3.2a0` release in order to create the project. See https://pypi.org/project/pytest-testinfra/

Related: https://github.com/philpep/testinfra/issues/484
Related: https://github.com/pytest-dev/meta/issues/1